### PR TITLE
Load modeled configuration from classpath resource mirrors

### DIFF
--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/ConfigurationEntrySorterTest.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/ConfigurationEntrySorterTest.java
@@ -51,6 +51,16 @@ public class ConfigurationEntrySorterTest {
 	}
 
 	@Test
+	public void sortFilesystemEntriesByExplicitArtifactOrigin() {
+		ClasspathEntry aArt = new ClasspathEntry("config/my-entity.yaml", asUrl("file:/mirror/a/config/my-entity.yaml"), "aaa-artifact");
+		ClasspathEntry zArt = new ClasspathEntry("config/my-entity.yaml", asUrl("file:/mirror/z/config/my-entity.yaml"), "zzz-artifact");
+
+		List<ClasspathEntry> sorted = sortEntries(zArt, aArt);
+
+		assertThat(sorted).containsExactly(aArt, zArt);
+	}
+
+	@Test
 	public void noPriority_noDisambiguator_defaultsToMinusOneAndEmpty() {
 		ClasspathEntry noPriority = cpEntry("artifact", "1.0", "my-entity~uc.yaml");
 		ClasspathEntry yesPriority = cpEntry("artifact", "1.0", "my-entity~uc.1.yaml");

--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/index/ClasspathIndexTest.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/index/ClasspathIndexTest.java
@@ -2,11 +2,16 @@ package com.braintribe.gm.config.yaml.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Tests for {@link ClasspathIndex}
@@ -16,6 +21,9 @@ import org.junit.Test;
 public class ClasspathIndexTest {
 
 	private final ClasspathIndex classpathIndex = new ClasspathIndex();
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@Test
 	public void findAll() throws Exception {
@@ -42,6 +50,27 @@ public class ClasspathIndexTest {
 		List<ClasspathEntry> entries = classpathIndex.forPrefix("bs-prefix");
 
 		assertThat(entries).isEmpty();
+	}
+
+	@Test
+	public void loadsArtifactScopedFilesystemMirror() throws Exception {
+		Path root = temporaryFolder.newFolder("classpath-resources").toPath();
+		Path artifact = root.resolve("example-configuration-1.0");
+		Path config = artifact.resolve("HICONIC-CONF/example.yaml");
+		Path index = artifact.resolve("META-INF/classpath-index.txt");
+		Path origin = artifact.resolve("META-INF/classpath-origin.properties");
+		Files.createDirectories(config.getParent());
+		Files.createDirectories(index.getParent());
+		Files.writeString(config, "example: true\n", StandardCharsets.UTF_8);
+		Files.writeString(index, "# preserved comment\nHICONIC-CONF/example.yaml\n", StandardCharsets.UTF_8);
+		Files.writeString(origin, "artifactId=example-configuration\n", StandardCharsets.UTF_8);
+
+		List<ClasspathEntry> entries = new ClasspathIndex(root).all();
+
+		assertThat(entries).hasSize(1);
+		assertThat(entries.get(0).path).isEqualTo("HICONIC-CONF/example.yaml");
+		assertThat(entries.get(0).origin).isEqualTo("example-configuration");
+		assertThat(entries.get(0).url.getProtocol()).isEqualTo("file");
 	}
 
 	@Test

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/ConfigurationEntrySorter.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/ConfigurationEntrySorter.java
@@ -36,25 +36,31 @@ import com.braintribe.logging.Logger;
 	private static ComparableEntry<ClasspathEntry> cpEntryToComparable(ClasspathEntry cpEntry) {
 		// e.g. "jar:file:/C:/maven-repo/res-on-cp/1.0/res-on-cp-1.0.jar!/config/my-config~use-case.disambig-8.yaml"
 		String fullPath = cpEntry.url.toString();
-		if (!fullPath.startsWith("jar:file:"))
-			throw new IllegalStateException("Only classpath entries for jar files are supported for config loading, but found: " + fullPath);
+		String artifactId = cpEntry.origin;
+		int i;
+		if (artifactId.isEmpty()) {
+			if (!fullPath.startsWith("jar:file:"))
+				throw new IllegalStateException("Classpath entry has neither an artifact origin nor a jar URL: " + fullPath);
 
-		int i = fullPath.indexOf(".jar!/");
-		if (i < 0)
-			throw new IllegalStateException("Invalid classpath entry url: " + fullPath + ". Expected format: jar:file:/path/to/jar!/path/inside/jar");
+			i = fullPath.indexOf(".jar!/");
+			if (i < 0)
+				throw new IllegalStateException("Invalid classpath entry url: " + fullPath
+						+ ". Expected format: jar:file:/path/to/jar!/path/inside/jar");
 
-		// e.g. jar:file:/C:/maven-repo/res-on-cp/1.0/res-on-cp-1.0
-		String jarPath = fullPath.substring(0, i);
-		i = jarPath.lastIndexOf("/");
-		if (i < 0)
-			throw new IllegalStateException("Invalid classpath entry url: " + fullPath + ". Expected format: jar:file:/path/to/jar!/path/inside/jar");
+			// e.g. jar:file:/C:/maven-repo/res-on-cp/1.0/res-on-cp-1.0
+			String jarPath = fullPath.substring(0, i);
+			i = jarPath.lastIndexOf("/");
+			if (i < 0)
+				throw new IllegalStateException("Invalid classpath entry url: " + fullPath
+						+ ". Expected format: jar:file:/path/to/jar!/path/inside/jar");
 
-		// e.g. res-on-cp-1.0
-		String artifactWithVersion = jarPath.substring(i + 1);
-		i = artifactWithVersion.lastIndexOf("-");
+			// e.g. res-on-cp-1.0
+			String artifactWithVersion = jarPath.substring(i + 1);
+			i = artifactWithVersion.lastIndexOf("-");
 
-		// e.g. res-on-cp
-		String artifactId = i > 0 ? artifactWithVersion.substring(0, i) : artifactWithVersion;
+			// e.g. res-on-cp
+			artifactId = i > 0 ? artifactWithVersion.substring(0, i) : artifactWithVersion;
+		}
 
 		// e.g. config/my-config~use-case.disambig-8.yaml
 		String path = cpEntry.path;

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/index/ClasspathEntry.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/index/ClasspathEntry.java
@@ -11,10 +11,16 @@ public class ClasspathEntry {
 
 	public final String path;
 	public final URL url;
+	public final String origin;
 
 	public ClasspathEntry(String path, URL url) {
+		this(path, url, "");
+	}
+
+	public ClasspathEntry(String path, URL url, String origin) {
 		this.path = NullSafe.nonNull(path, "path");
 		this.url = NullSafe.nonNull(url, "url");
+		this.origin = NullSafe.nonNull(origin, "origin");
 	}
 
 }

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/index/ClasspathIndex.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/index/ClasspathIndex.java
@@ -8,9 +8,12 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Properties;
 
 import com.braintribe.logging.Logger;
 import com.braintribe.utils.lcd.Lazy;
@@ -28,19 +31,31 @@ public class ClasspathIndex {
 	// toString: jar:file:/C:/maven-repo/res-on-cp/1.0/res-on-cp-1.0.jar!/META-INF/classpath-index.txt
 	// getPath : file:/C:/maven-repo/res-on-cp/1.0/res-on-cp-1.0.jar!/META-INF/classpath-index.txt
 	private static final String INDEX_FILE_NAME = "META-INF/classpath-index.txt";
+	private static final String ORIGIN_FILE_NAME = "META-INF/classpath-origin.properties";
 
 	private static final Logger log = Logger.getLogger(ClasspathIndex.class);
 
 	private final ClassLoader classLoader;
+	private final Path filesystemRoot;
 
 	private final Lazy<List<ClasspathEntry>> lazyIndex = new Lazy<List<ClasspathEntry>>(this::loadIndex);
 
 	public ClasspathIndex() {
-		this.classLoader = getClass().getClassLoader();
+		this(ClasspathIndex.class.getClassLoader(), null);
 	}
 
 	public ClasspathIndex(ClassLoader classLoader) {
+		this(classLoader, null);
+	}
+
+	/** Creates an index backed exclusively by an assembled filesystem mirror. */
+	public ClasspathIndex(Path filesystemRoot) {
+		this(null, requireFilesystemRoot(filesystemRoot));
+	}
+
+	private ClasspathIndex(ClassLoader classLoader, Path filesystemRoot) {
 		this.classLoader = classLoader;
+		this.filesystemRoot = filesystemRoot;
 	}
 
 	public List<ClasspathEntry> all() {
@@ -95,6 +110,17 @@ public class ClasspathIndex {
 	private List<ClasspathEntry> loadIndex() {
 		List<ClasspathEntry> entries = newList();
 
+		if (filesystemRoot != null)
+			loadFilesystemIndex(entries);
+		else
+			loadClasspathIndex(entries);
+
+		entries.sort((e1, e2) -> e1.path.compareTo(e2.path));
+
+		return entries;
+	}
+
+	private void loadClasspathIndex(List<ClasspathEntry> entries) {
 		try {
 			Enumeration<URL> resources = classLoader.getResources(INDEX_FILE_NAME);
 			while (resources.hasMoreElements())
@@ -103,10 +129,6 @@ public class ClasspathIndex {
 		} catch (IOException e) {
 			throw new UncheckedIOException("Error while getting Resources: " + INDEX_FILE_NAME, e);
 		}
-
-		entries.sort((e1, e2) -> e1.path.compareTo(e2.path));
-
-		return entries;
 	}
 
 	private void addEntriesFromIndexFile(URL indexFileUrl, List<ClasspathEntry> entries) {
@@ -138,7 +160,7 @@ public class ClasspathIndex {
 					URL fileUrl = files.nextElement();
 					if (fileUrl.getPath().startsWith(jarUrlPath)) {
 						found = true;
-						entries.add(new ClasspathEntry(line, fileUrl));
+						entries.add(new ClasspathEntry(line, fileUrl, artifactOrigin(indexFileUrl)));
 						break;
 					}
 				}
@@ -152,10 +174,83 @@ public class ClasspathIndex {
 		}
 	}
 
+	private void loadFilesystemIndex(List<ClasspathEntry> entries) {
+		if (!Files.isDirectory(filesystemRoot))
+			throw new IllegalStateException("Classpath resource mirror does not exist: " + filesystemRoot);
+
+		try (var children = Files.list(filesystemRoot)) {
+			for (Path artifactRoot : children.filter(Files::isDirectory).sorted().toList()) {
+				Path index = artifactRoot.resolve(INDEX_FILE_NAME);
+				if (Files.isRegularFile(index))
+					addEntriesFromFilesystemIndex(artifactRoot, index, entries);
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Error while inspecting classpath resource mirror: " + filesystemRoot, e);
+		}
+	}
+
+	private void addEntriesFromFilesystemIndex(Path artifactRoot, Path index, List<ClasspathEntry> entries) {
+		String origin = filesystemOrigin(artifactRoot);
+		try (var reader = Files.newBufferedReader(index, StandardCharsets.UTF_8)) {
+			String line;
+			int lineNum = -1;
+			while ((line = reader.readLine()) != null) {
+				lineNum++;
+				line = line.trim();
+				if (line.isEmpty() || line.startsWith("#"))
+					continue;
+
+				Path resource = artifactRoot.resolve(line).normalize();
+				if (!resource.startsWith(artifactRoot.normalize()) || !Files.isRegularFile(resource)) {
+					log.warn("File [" + line + "] referenced on line # " + lineNum
+							+ " not found in filesystem artifact mirror: " + index);
+					continue;
+				}
+				entries.add(new ClasspathEntry(line, resource.toUri().toURL(), origin));
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Error while reading filesystem classpath index: " + index, e);
+		}
+	}
+
+	private String filesystemOrigin(Path artifactRoot) {
+		Path originFile = artifactRoot.resolve(ORIGIN_FILE_NAME);
+		if (Files.isRegularFile(originFile)) {
+			Properties properties = new Properties();
+			try (var in = Files.newInputStream(originFile)) {
+				properties.load(in);
+				String artifactId = properties.getProperty("artifactId");
+				if (artifactId != null && !artifactId.isBlank())
+					return artifactId;
+			} catch (IOException e) {
+				throw new UncheckedIOException("Error while reading classpath resource origin: " + originFile, e);
+			}
+		}
+		return artifactRoot.getFileName().toString();
+	}
+
+	private String artifactOrigin(URL indexFileUrl) {
+		String value = indexFileUrl.toString();
+		int jarEnd = value.indexOf(".jar!/");
+		if (jarEnd >= 0) {
+			int slash = value.lastIndexOf('/', jarEnd);
+			String artifactWithVersion = value.substring(slash + 1, jarEnd);
+			int versionSeparator = artifactWithVersion.lastIndexOf('-');
+			return versionSeparator > 0 ? artifactWithVersion.substring(0, versionSeparator) : artifactWithVersion;
+		}
+		return "";
+	}
+
 	private String artifactPrefix(URL indexFileUrl) {
 		String path = indexFileUrl.getPath();
 		if (!path.endsWith(INDEX_FILE_NAME))
 			return null;
 		return path.substring(0, path.length() - INDEX_FILE_NAME.length());
+	}
+
+	private static Path requireFilesystemRoot(Path path) {
+		if (path == null)
+			throw new NullPointerException("filesystemRoot must not be null");
+		return path;
 	}
 }


### PR DESCRIPTION
## Summary
- add an exclusive filesystem-backed `ClasspathIndex` mode for assembled RX applications
- retain artifact origin metadata so modeled configuration keeps deterministic artifact ordering
- preserve the existing classloader-backed behavior for IDE and CX launches

## Compatibility
- default constructors continue to load from the classloader
- filesystem lookup is used only when explicitly constructed with a mirror root
- jar-origin sorting remains compatible with the existing artifact-name derivation

## Validation
- focused `modeled-yaml-config-test` suite
- full `hc .` group build across 261 artifacts
- `git diff --check`
