### PR TITLE
Support value descriptors in configuration merges

### DIFF
--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/EntityMergerTest.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/EntityMergerTest.java
@@ -16,6 +16,9 @@ import com.braintribe.gm.model.reason.config.IncompatibleMergeTypes;
 import com.braintribe.model.generic.GenericEntity;
 import com.braintribe.model.generic.pr.AbsenceInformation;
 import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.generic.reflection.Property;
+import com.braintribe.model.generic.value.Variable;
+import com.braintribe.model.generic.value.ValueDescriptor;
 
 /**
  * Tests for {@link EntityMerger}
@@ -80,6 +83,44 @@ public class EntityMergerTest {
 	}
 
 	@Test
+	public void presentVdProperty_NotOverriddenOrDereferenced() {
+		MergedEntity eRoot = MergedEntity.T.create();
+		setVariable(eRoot, "string", "ENTITY_VALUE");
+
+		MergedEntity dRoot = MergedEntity.T.create();
+		dRoot.setString("default-value");
+
+		merge(eRoot, dRoot);
+
+		assertVariable(eRoot, "string", "ENTITY_VALUE");
+	}
+
+	@Test
+	public void absentProperty_TakesVdFromDefaults() {
+		MergedEntity eRoot = createAbsentEntity();
+
+		MergedEntity dRoot = MergedEntity.T.create();
+		setVariable(dRoot, "string", "DEFAULT_VALUE");
+
+		merge(eRoot, dRoot);
+
+		assertVariable(eRoot, "string", "DEFAULT_VALUE");
+	}
+
+	@Test
+	public void concreteProperty_OverridesVdDefault() {
+		MergedEntity eRoot = MergedEntity.T.create();
+		eRoot.setString("entity-value");
+
+		MergedEntity dRoot = MergedEntity.T.create();
+		setVariable(dRoot, "string", "DEFAULT_VALUE");
+
+		merge(eRoot, dRoot);
+
+		assertThat(eRoot.getString()).isEqualTo("entity-value");
+	}
+
+	@Test
 	public void absentEntityProperty_TakenFromDefaults() {
 		MergedEntity eRoot = createAbsentEntity();
 
@@ -121,6 +162,44 @@ public class EntityMergerTest {
 		merge(eRoot, dRoot);
 
 		assertThat(eRoot.getListStr()).containsExactly("x");
+	}
+
+	@Test
+	public void presentCollectionVd_OverridesConcreteDefaultWithoutMerge() {
+		MergedEntity eRoot = MergedEntity.T.create();
+		setVariable(eRoot, "listStr", "ENTITY_LIST");
+
+		MergedEntity dRoot = MergedEntity.T.create();
+		dRoot.getListStr().add("default");
+
+		merge(eRoot, dRoot);
+
+		assertVariable(eRoot, "listStr", "ENTITY_LIST");
+	}
+
+	@Test
+	public void absentCollection_TakesVdFromDefaults() {
+		MergedEntity eRoot = createAbsentEntity();
+
+		MergedEntity dRoot = MergedEntity.T.create();
+		setVariable(dRoot, "listStr", "DEFAULT_LIST");
+
+		merge(eRoot, dRoot);
+
+		assertVariable(eRoot, "listStr", "DEFAULT_LIST");
+	}
+
+	@Test
+	public void concreteCollection_OverridesVdDefaultWithoutMerge() {
+		MergedEntity eRoot = MergedEntity.T.create();
+		eRoot.getListStr().add("entity");
+
+		MergedEntity dRoot = MergedEntity.T.create();
+		setVariable(dRoot, "listStr", "DEFAULT_LIST");
+
+		merge(eRoot, dRoot);
+
+		assertThat(eRoot.getListStr()).containsExactly("entity");
 	}
 
 	@Test
@@ -602,6 +681,20 @@ public class EntityMergerTest {
 		assertThat(result).isSameAs(eRoot);
 
 		return resultMaybe.whyUnsatisfied();
+	}
+
+	private static void setVariable(MergedEntity entity, String propertyName, String variableName) {
+		Variable variable = Variable.T.create();
+		variable.setName(variableName);
+		MergedEntity.T.getProperty(propertyName).setVdDirect(entity, variable);
+	}
+
+	private static void assertVariable(MergedEntity entity, String propertyName, String variableName) {
+		Property property = MergedEntity.T.getProperty(propertyName);
+		ValueDescriptor descriptor = property.getVdDirect(entity);
+
+		assertThat(descriptor).isInstanceOf(Variable.class);
+		assertThat(((Variable) descriptor).getName()).isEqualTo(variableName);
 	}
 
 	/**

--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/ModeledYamlConfigurationTest.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/ModeledYamlConfigurationTest.java
@@ -26,6 +26,8 @@ import com.braintribe.model.generic.GMF;
 import com.braintribe.model.generic.GenericEntity;
 import com.braintribe.model.generic.reflection.EntityType;
 import com.braintribe.model.generic.reflection.Property;
+import com.braintribe.model.generic.value.Variable;
+import com.braintribe.model.generic.value.ValueDescriptor;
 
 /**
  * Tests for {@link ModeledYamlConfiguration}.
@@ -128,6 +130,32 @@ public class ModeledYamlConfigurationTest {
 
 	}
 
+	@Test
+	public void classpathValueOverridesProgrammaticVdDefault() {
+		setClasspathIndex();
+
+		LoadedEntity beforeClasspath = createAbsentEntity();
+		setVariable(beforeClasspath, "cpValue", "CP_DEFAULT");
+		myc.registerConfiguration("symbolic default", LoadedEntity.T, "", ConfigurationStage.beforeClasspath, 0, () -> beforeClasspath);
+
+		LoadedEntity entity = load();
+
+		assertThat(entity.getCpValue()).isEqualTo("cp-value");
+	}
+
+	@Test
+	public void programmaticVdOverrideSurvivesClasspathMerge() {
+		setClasspathIndex();
+
+		LoadedEntity afterClasspath = createAbsentEntity();
+		setVariable(afterClasspath, "cpValue", "CP_OVERRIDE");
+		myc.registerConfiguration("symbolic override", LoadedEntity.T, "", ConfigurationStage.afterEverythingElse, 0, () -> afterClasspath);
+
+		LoadedEntity entity = load();
+
+		assertVariable(entity, "cpValue", "CP_OVERRIDE");
+	}
+
 	private void registerProgrammaticSources() {
 		LoadedEntity beforeCp = createAbsentEntity();
 		beforeCp.setOrigin("code-before-cp");
@@ -172,6 +200,19 @@ public class ModeledYamlConfigurationTest {
 			p.setAbsenceInformation(e, GMF.absenceInformation());
 
 		return e;
+	}
+
+	private static void setVariable(LoadedEntity entity, String propertyName, String variableName) {
+		Variable variable = Variable.T.create();
+		variable.setName(variableName);
+		LoadedEntity.T.getProperty(propertyName).setVdDirect(entity, variable);
+	}
+
+	private static void assertVariable(LoadedEntity entity, String propertyName, String variableName) {
+		ValueDescriptor descriptor = LoadedEntity.T.getProperty(propertyName).getVdDirect(entity);
+
+		assertThat(descriptor).isInstanceOf(Variable.class);
+		assertThat(((Variable) descriptor).getName()).isEqualTo(variableName);
 	}
 
 }

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/EntityMerger.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/EntityMerger.java
@@ -6,6 +6,8 @@ import static com.braintribe.utils.lcd.CollectionTools2.newSet;
 import static com.braintribe.utils.lcd.CollectionTools2.removeFirst;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -27,7 +29,7 @@ import com.braintribe.model.generic.reflection.EntityType;
 import com.braintribe.model.generic.reflection.GenericModelType;
 import com.braintribe.model.generic.reflection.MapType;
 import com.braintribe.model.generic.reflection.Property;
-import com.braintribe.model.generic.reflection.StandardTraversingContext;
+import com.braintribe.model.generic.reflection.VdHolder;
 
 /**
  * @author peter.gazdik
@@ -127,18 +129,34 @@ import com.braintribe.model.generic.reflection.StandardTraversingContext;
 				continue;
 
 			boolean eAbsent = p.isAbsent(entity);
+			Object dDirectValue = p.getDirectUnsafe(defaults);
 			if (eAbsent && !p.getType().areCustomInstancesReachable()) {
-				Object dValue = p.getDirectUnsafe(defaults);
-				p.setDirectUnsafe(entity, dValue);
+				p.setDirectUnsafe(entity, dDirectValue);
 				continue;
 			}
 			if (eAbsent) {
-				Object dValue = p.getDirectUnsafe(defaults);
-				if (dValue instanceof GenericEntity) {
-					p.setDirectUnsafe(entity, findSanitizedElement(dValue));
+				if (dDirectValue instanceof GenericEntity) {
+					p.setDirectUnsafe(entity, findSanitizedElement(dDirectValue));
+					continue;
+				}
+				if (VdHolder.isVdHolder(dDirectValue)) {
+					p.setDirectUnsafe(entity, dDirectValue);
 					continue;
 				}
 			}
+
+			Object eDirectValue = p.getDirectUnsafe(entity);
+			// A value descriptor represents the complete property value. It is therefore
+			// an explicit override, not a collection that can participate in a merge.
+			// Absence information is also represented by a VdHolder, but must continue
+			// into the normal default-filling path.
+			if (!eAbsent && VdHolder.isVdHolder(eDirectValue))
+				continue;
+
+			// A descriptor from defaults only applies when the property is absent. A
+			// concrete value in the higher-priority entity overrides it completely.
+			if (VdHolder.isVdHolder(dDirectValue))
+				continue;
 
 			Object eValue = p.get(entity);
 			if (!eAbsent && eValue == null)
@@ -234,17 +252,34 @@ import com.braintribe.model.generic.reflection.StandardTraversingContext;
 	}
 
 	private static Map<String, GenericEntity> indexByGid(GenericEntity entity) {
-		StandardTraversingContext traversingContext = new StandardTraversingContext();
-
-		entity.entityType().traverse(traversingContext, entity);
-
 		Map<String, GenericEntity> gidToEntity = newMap();
-
-		for (GenericEntity e : traversingContext.getVisitedObjects())
-			if (e.getGlobalId() != null)
-				gidToEntity.put(e.getGlobalId(), e);
-
+		Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+		indexByGid(entity, gidToEntity, visited);
 		return gidToEntity;
+	}
+
+	private static void indexByGid(Object value, Map<String, GenericEntity> gidToEntity, Set<Object> visited) {
+		if (value == null || VdHolder.isVdHolder(value) || !visited.add(value))
+			return;
+
+		if (value instanceof GenericEntity entity) {
+			String gid = entity.getGlobalId();
+			if (gid != null)
+				gidToEntity.put(gid, entity);
+
+			for (Property property : entity.entityType().getProperties())
+				indexByGid(property.getDirectUnsafe(entity), gidToEntity, visited);
+
+		} else if (value instanceof Map<?, ?> map) {
+			for (Entry<?, ?> entry : map.entrySet()) {
+				indexByGid(entry.getKey(), gidToEntity, visited);
+				indexByGid(entry.getValue(), gidToEntity, visited);
+			}
+
+		} else if (value instanceof Iterable<?> iterable) {
+			for (Object element : iterable)
+				indexByGid(element, gidToEntity, visited);
+		}
 	}
 
 	//
@@ -262,10 +297,11 @@ import com.braintribe.model.generic.reflection.StandardTraversingContext;
 			if (p.isAbsent(defaults))
 				continue;
 
-			Object dValue = p.get(defaults);
-			if (dValue == null)
+			Object dDirectValue = p.getDirectUnsafe(defaults);
+			if (dDirectValue == null || VdHolder.isVdHolder(dDirectValue))
 				continue;
 
+			Object dValue = p.get(defaults);
 			GenericModelType dType = p.getType();
 			if (dType.isBase())
 				dType = GMF.getTypeReflection().getType(dValue);


### PR DESCRIPTION
Makes the canonical modeled YAML EntityMerger preserve VD-backed scalar and collection properties without dereferencing them as concrete values. Presence remains authoritative: a present descriptor is a complete override, an absent property inherits a descriptor from defaults, and a concrete higher-priority value overrides a symbolic default.

The global-id index and sanitation paths now treat VdHolder values as symbolic leaves. Tests cover direct scalar and collection merge semantics plus integration through ClasspathIndex, configuration stages, and the canonical merger.

Verification:
- hc compile (modeled-yaml-config-test)
- hc install (modeled-yaml-config)
- hc test (modeled-yaml-config-test)