### PR TITLE
Add partial configuration placeholder resolution

### DIFF
--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/ModeledYamlConfigurationLoaderTest.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/ModeledYamlConfigurationLoaderTest.java
@@ -1,0 +1,148 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package com.braintribe.gm.config.yaml;
+
+import static com.braintribe.testing.junit.assertions.assertj.core.api.Assertions.assertThat;
+import static com.braintribe.testing.junit.assertions.gm.assertj.core.api.GmAssertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.braintribe.gm.config.yaml.api.PartiallyResolvedConfiguration;
+import com.braintribe.gm.config.yaml.model.LoadedEntity;
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.model.reason.Reasons;
+import com.braintribe.gm.model.reason.config.ConfigurationError;
+import com.braintribe.gm.model.reason.config.ConfigurationEvaluationError;
+import com.braintribe.gm.model.reason.config.PropertyNotFound;
+import com.braintribe.gm.model.reason.essential.InternalError;
+import com.braintribe.model.bvd.convert.ToInteger;
+import com.braintribe.model.bvd.convert.ToString;
+import com.braintribe.model.bvd.string.Concatenation;
+import com.braintribe.model.generic.session.InputStreamProvider;
+import com.braintribe.model.generic.value.ValueDescriptor;
+import com.braintribe.model.generic.value.Variable;
+
+public class ModeledYamlConfigurationLoaderTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void strictRuntimeReadFailsForMissingVariables() {
+		Maybe<LoadedEntity> result = loader().loadConfig(LoadedEntity.T, yaml("cpValue: ${MISSING}"));
+
+		assertThat(result).isUnsatisfiedBy(ConfigurationEvaluationError.T);
+		assertThat(result.whyUnsatisfied().getReasons()).hasSize(1);
+		assertThat(result.whyUnsatisfied().getReasons().get(0)).isInstanceOf(PropertyNotFound.class);
+	}
+
+	@Test
+	public void partialBuildReadResolvesKnownAndRetainsUnknownVariables() {
+		ModeledYamlConfigurationLoader loader = loader().variableResolver(name -> switch (name) {
+		case "KNOWN" -> "resolved";
+		default -> null;
+		});
+
+		Maybe<PartiallyResolvedConfiguration<LoadedEntity>> result = loader.loadConfigPartially(LoadedEntity.T,
+				yaml("""
+						cpValue: ${KNOWN}-${MISSING}
+						integerValue: ${PORT}
+						"""));
+
+		assertThat(result).isSatisfied();
+		PartiallyResolvedConfiguration<LoadedEntity> partial = result.get();
+		assertThat(partial.unresolvedVariables()).containsExactlyInAnyOrder("MISSING", "PORT");
+
+		ValueDescriptor cpValue = LoadedEntity.T.getProperty("cpValue").getVdDirect(partial.configuration());
+		assertThat(cpValue).isInstanceOf(ToString.class);
+		assertThat(((ToString) cpValue).getOperand()).isInstanceOf(Concatenation.class);
+		Concatenation concatenation = (Concatenation) ((ToString) cpValue).getOperand();
+		assertThat(concatenation.getOperands()).hasSize(3);
+		assertThat(concatenation.getOperands().get(0)).isEqualTo("resolved");
+		assertThat(concatenation.getOperands().get(1)).isEqualTo("-");
+		assertVariable(concatenation.getOperands().get(2), "MISSING");
+
+		ValueDescriptor integerValue = LoadedEntity.T.getProperty("integerValue").getVdDirect(partial.configuration());
+		assertThat(integerValue).isInstanceOf(ToInteger.class);
+		assertVariable(((ToInteger) integerValue).getOperand(), "PORT");
+	}
+
+	@Test
+	public void partialBuildReadEvaluatesClosedTypedExpressions() {
+		ModeledYamlConfigurationLoader loader = loader().variableResolver(name -> name.equals("PORT") ? "4711" : null);
+
+		Maybe<PartiallyResolvedConfiguration<LoadedEntity>> result = loader.loadConfigPartially(LoadedEntity.T,
+				yaml("integerValue: ${PORT}"));
+
+		assertThat(result).isSatisfied();
+		assertThat(result.get().unresolvedVariables()).isEmpty();
+		assertThat(result.get().configuration().getIntegerValue()).isEqualTo(4711);
+	}
+
+	@Test
+	public void partialBuildReadDoesNotHideResolverFailures() {
+		ModeledYamlConfigurationLoader loader = loader().variableResolverReasoned(name -> Reasons.build(ConfigurationError.T)
+				.text("Resolver failed").toMaybe());
+
+		Maybe<PartiallyResolvedConfiguration<LoadedEntity>> result = loader.loadConfigPartially(LoadedEntity.T,
+				yaml("cpValue: ${BROKEN}"));
+
+		assertThat(result).isUnsatisfiedBy(ConfigurationError.T);
+	}
+
+	@Test
+	public void partialBuildReadDoesNotHideTypeConversionFailures() {
+		ModeledYamlConfigurationLoader loader = loader().variableResolver(name -> "not-an-integer");
+
+		Maybe<PartiallyResolvedConfiguration<LoadedEntity>> result = loader.loadConfigPartially(LoadedEntity.T,
+				yaml("integerValue: ${PORT}"));
+
+		assertThat(result).isUnsatisfiedBy(InternalError.T);
+	}
+
+	@Test
+	public void partialFileReadResolvesSourceLocationVariables() throws Exception {
+		File configFile = temporaryFolder.newFile("loaded-entity.yaml");
+		Files.writeString(configFile.toPath(), "cpValue: ${config.dir}", StandardCharsets.UTF_8);
+
+		Maybe<PartiallyResolvedConfiguration<LoadedEntity>> result = loader().loadConfigPartially(LoadedEntity.T, configFile, true);
+
+		assertThat(result).isSatisfied();
+		assertThat(result.get().unresolvedVariables()).isEmpty();
+		assertThat(result.get().configuration().getCpValue()).isEqualTo(configFile.getParentFile().getAbsolutePath());
+	}
+
+	private static ModeledYamlConfigurationLoader loader() {
+		return new ModeledYamlConfigurationLoader();
+	}
+
+	private static InputStreamProvider yaml(String yaml) {
+		byte[] bytes = yaml.getBytes(StandardCharsets.UTF_8);
+		return () -> new ByteArrayInputStream(bytes);
+	}
+
+	private static void assertVariable(Object value, String name) {
+		assertThat(value).isInstanceOf(Variable.class);
+		assertThat(((Variable) value).getName()).isEqualTo(name);
+	}
+}

--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/model/LoadedEntity.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/model/LoadedEntity.java
@@ -37,4 +37,7 @@ public interface LoadedEntity extends GenericEntity {
 	boolean getPrimitiveBoolean();
 	void setPrimitiveBoolean(boolean primitiveBoolean);
 
+	Integer getIntegerValue();
+	void setIntegerValue(Integer integerValue);
+
 }

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/ConfigVariableResolver.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/ConfigVariableResolver.java
@@ -65,30 +65,38 @@ public class ConfigVariableResolver {
 	}
 
 	public String resolve(Variable var) {
-		return resolve(var.getName());
+		String name = var.getName();
+		Maybe<String> valueMaybe = resolveReasoned(name);
+
+		if (valueMaybe.isSatisfied())
+			return valueMaybe.get();
+
+		acquireFailure().getReasons().add(valueMaybe.whyUnsatisfied());
+		return "${" + name + "}";
 	}
 
-	private String resolve(String var) {
+	public Maybe<String> resolveReasoned(Variable var) {
+		return resolveReasoned(var.getName());
+	}
+
+	private Maybe<String> resolveReasoned(String var) {
 		if (var.startsWith(PropertyResolutions.ENV_PREFIX)) {
 			String envName = var.substring(PropertyResolutions.ENV_PREFIX.length());
 
 			String value = virtualEnvironment.getEnv(envName);
 
-			if (value == null) {
-				acquireFailure().getReasons().add(PropertyNotFound.create(var));
-				return "${" + var + "}";
-			}
+			if (value == null)
+				return PropertyNotFound.create(var).asMaybe();
 
-			// return var;
-			return value;
+			return Maybe.complete(value);
 		}
 		
 		switch (var) {
 		case "config.base":
 		case "config.dir":
-			return dirProperty;
+			return Maybe.complete(dirProperty);
 		case "config.file":
-			return fileProperty;
+			return Maybe.complete(fileProperty);
 		default:
 			break;
 		}
@@ -97,22 +105,18 @@ public class ConfigVariableResolver {
 			Maybe<String> valueMaybe = variableResolver.apply(var);
 			
 			if (valueMaybe.isSatisfied())
-				return valueMaybe.get();
+				return valueMaybe;
 			
-			if (!valueMaybe.isUnsatisfiedBy(NotFound.T)) {
-				acquireFailure().getReasons().add(valueMaybe.whyUnsatisfied());
-				return "${" + var + "}";
-			}
+			if (!valueMaybe.isUnsatisfiedBy(NotFound.T))
+				return valueMaybe;
 		}
 
 		String value = virtualEnvironment.getProperty(var);
 
-		if (value == null) {
-			acquireFailure().getReasons().add(PropertyNotFound.create(var)); //
-			return "${" + var + "}";
-		}
+		if (value == null)
+			return PropertyNotFound.create(var).asMaybe();
 
-		return value;
+		return Maybe.complete(value);
 	}
 
 	private Reason acquireFailure() {

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/ModeledYamlConfigurationLoader.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/ModeledYamlConfigurationLoader.java
@@ -16,12 +16,15 @@
 package com.braintribe.gm.config.yaml;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import com.braintribe.gm.config.yaml.api.PartiallyResolvedConfiguration;
 import com.braintribe.gm.model.reason.Maybe;
 import com.braintribe.gm.model.reason.ReasonException;
 import com.braintribe.gm.model.reason.Reasons;
@@ -80,6 +83,68 @@ public class ModeledYamlConfigurationLoader {
 		} catch (ReasonException e) {
 			return e.getReason().asMaybe();
 		}
+	}
+
+	/**
+	 * Reads a configuration for build-time assembly. Available variables are resolved, while genuinely unavailable variables remain represented by
+	 * value descriptors and are reported in the result. Runtime loading must continue to use {@link #loadConfig(EntityType, InputStreamProvider)},
+	 * which fails for every unresolved variable.
+	 */
+	public <C extends GenericEntity> Maybe<PartiallyResolvedConfiguration<C>> loadConfigPartially(EntityType<C> configType,
+			InputStreamProvider inputStreamProvider) {
+		ConfigVariableResolver configVariableResolver = newConfigVariableResolver(null);
+
+		try (InputStream in = inputStreamProvider.openInputStream()) {
+			return loadConfigPartially(configType, in, configVariableResolver);
+
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+
+		} catch (ReasonException e) {
+			return e.getReason().asMaybe();
+		}
+	}
+
+	public <C extends GenericEntity> Maybe<PartiallyResolvedConfiguration<C>> loadConfigPartially(EntityType<C> configType, File configFile,
+			boolean fileMustExist) {
+		if (!configFile.exists()) {
+			if (fileMustExist)
+				return Reasons.build(NotFound.T).text("Configuration file " + configFile.getAbsolutePath() + " does not exist").toMaybe();
+
+			return Maybe.complete(new PartiallyResolvedConfiguration<>(configType.create(), Set.of()));
+		}
+
+		ConfigVariableResolver configVariableResolver = newConfigVariableResolver(configFile);
+
+		try (InputStream in = new FileInputStream(configFile)) {
+			return loadConfigPartially(configType, in, configVariableResolver);
+
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+
+		} catch (ReasonException e) {
+			return e.getReason().asMaybe();
+		}
+	}
+
+	private ConfigVariableResolver newConfigVariableResolver(File configFile) {
+		ConfigVariableResolver configVariableResolver = new ConfigVariableResolver(virtualEnvironment, configFile);
+		if (variableResolver != null)
+			configVariableResolver.setVariableResolverReasoned(variableResolver);
+		return configVariableResolver;
+	}
+
+	private <C extends GenericEntity> Maybe<PartiallyResolvedConfiguration<C>> loadConfigPartially(EntityType<C> configType, InputStream in,
+			ConfigVariableResolver configVariableResolver) {
+		Maybe<C> configMaybe = YamlConfigurations.<C> read(configType) //
+				.placeholders() //
+				.absentifyMissingProperties(shouldAbsentify) //
+				.from(in);
+
+		if (configMaybe.isUnsatisfied())
+			return configMaybe.whyUnsatisfied().asMaybe();
+
+		return new PartialConfigPlaceholderResolver(configVariableResolver).resolve(configMaybe.get());
 	}
 
 	public <C extends GenericEntity> Maybe<C> loadConfig(EntityType<C> configType, File configFile, boolean fileMustExist) {

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/PartialConfigPlaceholderResolver.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/PartialConfigPlaceholderResolver.java
@@ -1,0 +1,210 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package com.braintribe.gm.config.yaml;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.braintribe.gm.config.yaml.api.PartiallyResolvedConfiguration;
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.gm.model.reason.Reason;
+import com.braintribe.gm.model.reason.essential.NotFound;
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.reflection.Property;
+import com.braintribe.model.generic.reflection.VdHolder;
+import com.braintribe.model.generic.value.ValueDescriptor;
+import com.braintribe.model.generic.value.Variable;
+
+/**
+ * Substitutes the available leaves of a placeholder expression while retaining expressions which still depend on unavailable variables.
+ */
+class PartialConfigPlaceholderResolver {
+	private final ConfigVariableResolver variableResolver;
+	private final Set<String> unresolvedVariables = new LinkedHashSet<>();
+	private final IdentityHashMap<Object, Object> transformed = new IdentityHashMap<>();
+	private Reason failure;
+
+	PartialConfigPlaceholderResolver(ConfigVariableResolver variableResolver) {
+		this.variableResolver = variableResolver;
+	}
+
+	<C> Maybe<PartiallyResolvedConfiguration<C>> resolve(C configuration) {
+		Object result = transform(configuration, true);
+
+		if (failure != null)
+			return failure.asMaybe();
+
+		@SuppressWarnings("unchecked")
+		C typedResult = (C) result;
+		return Maybe.complete(new PartiallyResolvedConfiguration<>(typedResult, unresolvedVariables));
+	}
+
+	private Object transform(Object value, boolean evaluateDescriptor) {
+		if (value == null || failure != null)
+			return value;
+
+		if (VdHolder.isVdHolder(value))
+			return transformDescriptor(((VdHolder) value).vd);
+
+		if (value instanceof Variable variable)
+			return resolveVariable(variable);
+
+		if (value instanceof ValueDescriptor descriptor)
+			return evaluateDescriptor ? transformDescriptor(descriptor) : transformEntity(descriptor, false);
+
+		if (value instanceof GenericEntity entity)
+			return transformEntity(entity, true);
+
+		if (value instanceof Map<?, ?> map)
+			return transformMap(map, evaluateDescriptor);
+
+		if (value instanceof Collection<?> collection)
+			return transformCollection(collection, evaluateDescriptor);
+
+		return value;
+	}
+
+	private Object transformDescriptor(ValueDescriptor descriptor) {
+		Object transformedDescriptor = transformEntity(descriptor, false);
+		Set<String> descriptorUnresolved = collectUnresolvedVariables(transformedDescriptor);
+
+		if (!descriptorUnresolved.isEmpty())
+			return transformedDescriptor;
+
+		Maybe<Object> evaluated = YamlConfigurations.resolvePlaceholders(transformedDescriptor,
+				variable -> {
+					throw new IllegalStateException("Unexpected unresolved variable " + variable.getName());
+				});
+
+		if (evaluated.isUnsatisfied()) {
+			failure = evaluated.whyUnsatisfied();
+			return transformedDescriptor;
+		}
+
+		return evaluated.get();
+	}
+
+	private Set<String> collectUnresolvedVariables(Object value) {
+		Set<String> result = new LinkedHashSet<>();
+		collectUnresolvedVariables(value, result, new IdentityHashMap<>());
+		return result;
+	}
+
+	private void collectUnresolvedVariables(Object value, Set<String> result, IdentityHashMap<Object, Boolean> visited) {
+		if (value == null || visited.put(value, Boolean.TRUE) != null)
+			return;
+
+		if (VdHolder.isVdHolder(value)) {
+			collectUnresolvedVariables(((VdHolder) value).vd, result, visited);
+			return;
+		}
+
+		if (value instanceof Variable variable) {
+			result.add(variable.getName());
+			return;
+		}
+
+		if (value instanceof GenericEntity entity) {
+			for (Property property : entity.entityType().getProperties())
+				collectUnresolvedVariables(property.getDirect(entity), result, visited);
+			return;
+		}
+
+		if (value instanceof Map<?, ?> map) {
+			map.forEach((key, entryValue) -> {
+				collectUnresolvedVariables(key, result, visited);
+				collectUnresolvedVariables(entryValue, result, visited);
+			});
+			return;
+		}
+
+		if (value instanceof Collection<?> collection)
+			collection.forEach(element -> collectUnresolvedVariables(element, result, visited));
+	}
+
+	private Object resolveVariable(Variable variable) {
+		Maybe<String> valueMaybe = variableResolver.resolveReasoned(variable);
+
+		if (valueMaybe.isSatisfied())
+			return valueMaybe.get();
+
+		if (valueMaybe.isUnsatisfiedBy(NotFound.T)) {
+			unresolvedVariables.add(variable.getName());
+			return variable;
+		}
+
+		failure = valueMaybe.whyUnsatisfied();
+		return variable;
+	}
+
+	private GenericEntity transformEntity(GenericEntity entity, boolean evaluateDescriptors) {
+		if (transformed.put(entity, entity) != null)
+			return entity;
+
+		for (Property property : entity.entityType().getProperties()) {
+			Object directValue = property.getDirect(entity);
+			Object transformedValue = transform(directValue, evaluateDescriptors);
+
+			if (transformedValue == directValue)
+				continue;
+
+			if (transformedValue instanceof ValueDescriptor descriptor)
+				property.setVdDirect(entity, descriptor);
+			else
+				property.setDirectUnsafe(entity, transformedValue);
+		}
+
+		return entity;
+	}
+
+	private Map<Object, Object> transformMap(Map<?, ?> map, boolean evaluateDescriptors) {
+		Object known = transformed.get(map);
+		if (known != null)
+			return castMap(known);
+
+		Map<Object, Object> result = new LinkedHashMap<>();
+		transformed.put(map, result);
+		map.forEach((key, value) -> result.put(transform(key, evaluateDescriptors), transform(value, evaluateDescriptors)));
+		return result;
+	}
+
+	private Collection<Object> transformCollection(Collection<?> collection, boolean evaluateDescriptors) {
+		Object known = transformed.get(collection);
+		if (known != null)
+			return castCollection(known);
+
+		Collection<Object> result = collection instanceof Set<?> ? new LinkedHashSet<>() : new ArrayList<>(collection.size());
+		transformed.put(collection, result);
+		for (Object element : collection)
+			result.add(transform(element, evaluateDescriptors));
+		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<Object, Object> castMap(Object value) {
+		return (Map<Object, Object>) value;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Collection<Object> castCollection(Object value) {
+		return (Collection<Object>) value;
+	}
+}

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/api/PartiallyResolvedConfiguration.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/api/PartiallyResolvedConfiguration.java
@@ -1,0 +1,32 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package com.braintribe.gm.config.yaml.api;
+
+import java.util.Set;
+
+/**
+ * Result of a build-time configuration read.
+ * <p>
+ * Variables which could be resolved have already been evaluated. Variables which were genuinely unavailable remain as value descriptors in the
+ * configuration and are listed in {@link #unresolvedVariables()}. Syntax, type conversion and resolver failures are not made lenient and still make
+ * the read fail.
+ */
+public record PartiallyResolvedConfiguration<C>(C configuration, Set<String> unresolvedVariables) {
+
+	public PartiallyResolvedConfiguration {
+		unresolvedVariables = Set.copyOf(unresolvedVariables);
+	}
+}


### PR DESCRIPTION
Summary:
- runtime configuration reads remain strict for unresolved placeholders
- explicit build-time partial read resolves available variables and preserves unavailable variables as value descriptors
- unresolved variable names are exposed for validation against deployment imports
- syntax, resolver, and type-conversion errors remain hard failures
- source-location variables are preserved for file reads

Verification:
- hc install in modeled-yaml-config
- hc compile and hc test in modeled-yaml-config-test
- all unit tests successful