### PR TITLE
Model configuration imports and partial assembly

### DIFF
--- a/configuration-assembly-model/.gitignore
+++ b/configuration-assembly-model/.gitignore
@@ -1,0 +1,3 @@
+/build
+/dist
+/classes

--- a/configuration-assembly-model/asset.man
+++ b/configuration-assembly-model/asset.man
@@ -1,0 +1,1 @@
+$nature = !com.braintribe.model.asset.natures.ModelPriming()

--- a/configuration-assembly-model/build.xml
+++ b/configuration-assembly-model/build.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns:bt="antlib:com.braintribe.build.ant.tasks" basedir="." default="install">
+	<bt:import artifact="com.braintribe.devrock.ant:model-ant-script#1.0" useCase="DEVROCK"/>
+</project>

--- a/configuration-assembly-model/class-gen/.gitignore
+++ b/configuration-assembly-model/class-gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/configuration-assembly-model/pom.xml
+++ b/configuration-assembly-model/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.braintribe.gm</groupId>
+		<artifactId>parent</artifactId>
+		<version>[2.0,2.1)</version>
+	</parent>
+	<artifactId>configuration-assembly-model</artifactId>
+	<version>2.0.1</version>
+	<properties>
+		<archetype>model</archetype>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>com.braintribe.gm</groupId>
+			<artifactId>root-model</artifactId>
+			<version>${V.com.braintribe.gm}</version>
+			<?tag asset?>
+		</dependency>
+	</dependencies>
+</project>

--- a/configuration-assembly-model/src/com/braintribe/gm/config/assembly/model/ConfigurationAssemblyReport.java
+++ b/configuration-assembly-model/src/com/braintribe/gm/config/assembly/model/ConfigurationAssemblyReport.java
@@ -1,0 +1,54 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package com.braintribe.gm.config.assembly.model;
+
+import java.util.List;
+
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.annotation.Initializer;
+import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.generic.reflection.EntityTypes;
+
+/** Machine-readable account of the static configuration closure produced for an application terminal. */
+public interface ConfigurationAssemblyReport extends GenericEntity {
+
+	EntityType<ConfigurationAssemblyReport> T = EntityTypes.T(ConfigurationAssemblyReport.class);
+
+	@Initializer("[]")
+	List<ConfigurationImport> getImports();
+	void setImports(List<ConfigurationImport> imports);
+
+	@Initializer("[]")
+	List<String> getUnresolvedVariables();
+	void setUnresolvedVariables(List<String> unresolvedVariables);
+
+	@Initializer("[]")
+	List<String> getUndeclaredVariables();
+	void setUndeclaredVariables(List<String> undeclaredVariables);
+
+	/** Symbolic inputs which the RX platform itself supplies rather than the deployment. */
+	@Initializer("[]")
+	List<String> getPlatformVariables();
+	void setPlatformVariables(List<String> platformVariables);
+
+	@Initializer("[]")
+	List<String> getAssembledConfigurations();
+	void setAssembledConfigurations(List<String> assembledConfigurations);
+
+	@Initializer("[]")
+	List<String> getResidualResources();
+	void setResidualResources(List<String> residualResources);
+}

--- a/configuration-assembly-model/src/com/braintribe/gm/config/assembly/model/ConfigurationImport.java
+++ b/configuration-assembly-model/src/com/braintribe/gm/config/assembly/model/ConfigurationImport.java
@@ -1,0 +1,40 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package com.braintribe.gm.config.assembly.model;
+
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.annotation.Initializer;
+import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.generic.reflection.EntityTypes;
+
+/** Declares one property which a packaged configuration intentionally imports from its deployment environment. */
+public interface ConfigurationImport extends GenericEntity {
+
+	EntityType<ConfigurationImport> T = EntityTypes.T(ConfigurationImport.class);
+
+	String getName();
+	void setName(String name);
+
+	@Initializer("true")
+	boolean getRequired();
+	void setRequired(boolean required);
+
+	boolean getConfidential();
+	void setConfidential(boolean confidential);
+
+	String getDescription();
+	void setDescription(String description);
+}

--- a/configuration-assembly-model/src/com/braintribe/gm/config/assembly/model/ConfigurationImports.java
+++ b/configuration-assembly-model/src/com/braintribe/gm/config/assembly/model/ConfigurationImports.java
@@ -1,0 +1,33 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package com.braintribe.gm.config.assembly.model;
+
+import java.util.List;
+
+import com.braintribe.model.generic.GenericEntity;
+import com.braintribe.model.generic.annotation.Initializer;
+import com.braintribe.model.generic.reflection.EntityType;
+import com.braintribe.model.generic.reflection.EntityTypes;
+
+/** Artifact-local declarations loaded from {@code META-INF/configuration-imports.yaml}. */
+public interface ConfigurationImports extends GenericEntity {
+
+	EntityType<ConfigurationImports> T = EntityTypes.T(ConfigurationImports.class);
+
+	@Initializer("[]")
+	List<ConfigurationImport> getImports();
+	void setImports(List<ConfigurationImport> imports);
+}

--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/ModeledYamlConfigurationTest.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/ModeledYamlConfigurationTest.java
@@ -17,11 +17,19 @@ import static com.braintribe.testing.junit.assertions.assertj.core.api.Assertion
 import static com.braintribe.testing.junit.assertions.gm.assertj.core.api.GmAssertions.assertThat;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import com.braintribe.gm.config.yaml.api.PartiallyResolvedConfiguration;
 import com.braintribe.gm.config.yaml.index.ClasspathIndex;
 import com.braintribe.gm.config.yaml.model.LoadedEntity;
+import com.braintribe.gm.model.reason.Maybe;
+import com.braintribe.model.bvd.convert.ToString;
+import com.braintribe.model.bvd.string.Concatenation;
 import com.braintribe.model.generic.GMF;
 import com.braintribe.model.generic.GenericEntity;
 import com.braintribe.model.generic.reflection.EntityType;
@@ -33,6 +41,9 @@ import com.braintribe.model.generic.value.ValueDescriptor;
  * Tests for {@link ModeledYamlConfiguration}.
  */
 public class ModeledYamlConfigurationTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	private final ModeledYamlConfiguration myc = new ModeledYamlConfiguration();
 
@@ -154,6 +165,49 @@ public class ModeledYamlConfigurationTest {
 		LoadedEntity entity = load();
 
 		assertVariable(entity, "cpValue", "CP_OVERRIDE");
+	}
+
+	@Test
+	public void staticPartialReadUsesRuntimeMergeAndRetainsUnknownVariables() throws Exception {
+		File configFolder = temporaryFolder.newFolder("partial-conf");
+		Files.writeString(new File(configFolder, "loaded-entity.low.yaml").toPath(), """
+				cpValue: ${KNOWN}-${MISSING}
+				fs1Value: low-priority
+				""", StandardCharsets.UTF_8);
+		Files.writeString(new File(configFolder, "loaded-entity.high-2.yaml").toPath(), """
+				fs1Value: high-priority
+				""", StandardCharsets.UTF_8);
+
+		myc.setConfigFolder(configFolder);
+		myc.setExternalPropertyLookup(name -> name.equals("KNOWN") ? "resolved" : null);
+
+		Maybe<PartiallyResolvedConfiguration<LoadedEntity>> result = myc.staticConfigPartiallyReasoned(LoadedEntity.T);
+
+		assertThat(result).isSatisfied();
+		PartiallyResolvedConfiguration<LoadedEntity> partial = result.get();
+		assertThat(partial.unresolvedVariables()).containsExactly("MISSING");
+		assertThat(partial.configuration().getFs1Value()).isEqualTo("high-priority");
+
+		ValueDescriptor descriptor = LoadedEntity.T.getProperty("cpValue").getVdDirect(partial.configuration());
+		assertThat(descriptor).isInstanceOf(ToString.class);
+		assertThat(((ToString) descriptor).getOperand()).isInstanceOf(Concatenation.class);
+		Concatenation concatenation = (Concatenation) ((ToString) descriptor).getOperand();
+		assertThat(concatenation.getOperands()).hasSize(3);
+		assertThat(concatenation.getOperands().get(0)).isEqualTo("resolved");
+		assertThat(concatenation.getOperands().get(1)).isEqualTo("-");
+		assertThat(concatenation.getOperands().get(2)).isInstanceOf(Variable.class);
+		assertThat(((Variable) concatenation.getOperands().get(2)).getName()).isEqualTo("MISSING");
+	}
+
+	@Test
+	public void staticPartialReadDoesNotInitializeProgrammaticConfiguration() {
+		LoadedEntity registered = createAbsentEntity();
+		registered.setAfterAllValue("must-not-be-assembled");
+		myc.registerConfiguration("runtime contribution", LoadedEntity.T, "", ConfigurationStage.afterEverythingElse, 0, () -> registered);
+
+		PartiallyResolvedConfiguration<LoadedEntity> partial = myc.staticConfigPartiallyReasoned(LoadedEntity.T).get();
+
+		assertThat(partial.configuration().getAfterAllValue()).isNull();
 	}
 
 	private void registerProgrammaticSources() {

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/ModeledYamlConfiguration.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/ModeledYamlConfiguration.java
@@ -33,8 +33,10 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -47,6 +49,7 @@ import com.braintribe.codec.marshaller.api.TypeExplicitnessOption;
 import com.braintribe.codec.marshaller.yaml.YamlMarshaller;
 import com.braintribe.common.lcd.function.CheckedFunction;
 import com.braintribe.gm.config.api.ModeledConfiguration;
+import com.braintribe.gm.config.yaml.api.PartiallyResolvedConfiguration;
 import com.braintribe.gm.config.yaml.index.ClasspathEntry;
 import com.braintribe.gm.config.yaml.index.ClasspathIndex;
 import com.braintribe.gm.model.reason.Maybe;
@@ -222,11 +225,60 @@ public class ModeledYamlConfiguration implements ModeledConfiguration {
 	private record ConfigEntry(GenericEntity entity, String origin) {
 	}
 
+	private record PartialConfigEntries(List<ConfigEntry> entries, Set<String> unresolvedVariables) {
+	}
+
 	@Override
 	public <C extends GenericEntity> Maybe<C> configReasoned(EntityType<C> configType, String useCase) {
 		// using the lazy initialized here is to avoid to block the map access and to do the actual loading afterwards
 		var configKey = new ConfigKey(configType, useCase);
 		return (Maybe<C>) configs.computeIfAbsent(configKey, k -> new Lazy<>(() -> this.loadConfig(configType, useCase))).get();
+	}
+
+	/**
+	 * Loads and merges the static classpath and filesystem layers while retaining placeholders which cannot be resolved in the current environment.
+	 * <p>
+	 * This is the build-time counterpart of {@link #configReasoned(EntityType, String)}. Programmatically registered contributions are deliberately
+	 * excluded because obtaining them would require application wiring and could introduce runtime side effects during assembly.
+	 */
+	public <C extends GenericEntity> Maybe<PartiallyResolvedConfiguration<C>> staticConfigPartiallyReasoned(EntityType<C> configType,
+			String useCase) {
+		Maybe<PartialConfigEntries> cpMaybe = readCpConfigPartially(configType, useCase);
+		Maybe<PartialConfigEntries> fsMaybe = readFsConfigPartially(configType, useCase);
+
+		if (cpMaybe.isUnsatisfied() || fsMaybe.isUnsatisfied()) {
+			var reasonAggregator = Reasons.aggregatorForceWrap(() -> ConfigurationError.create(//
+					"Error while partially loading static config of type [" + configType.getShortName() + "], use-case [" + useCase + "]"));
+
+			reasonAggregator.acceptMaybe(cpMaybe);
+			reasonAggregator.acceptMaybe(fsMaybe);
+
+			return reasonAggregator.get().asMaybe();
+		}
+
+		var reasonAggregator = Reasons.aggregatorForceWrap(() -> ConfigurationError.create(//
+				"Error while merging static config of type [" + configType.getShortName() + "], use-case [" + useCase + "]"));
+
+		ConfigEntry finalEntry = null;
+		finalEntry = mergeEntities(reasonAggregator, finalEntry, cpMaybe.get().entries());
+		finalEntry = mergeEntities(reasonAggregator, finalEntry, fsMaybe.get().entries());
+
+		@SuppressWarnings("unchecked")
+		C result = finalEntry != null ? (C) finalEntry.entity() : configType.create();
+		deepDeabsentify(result);
+
+		Set<String> unresolvedVariables = new LinkedHashSet<>(cpMaybe.get().unresolvedVariables());
+		unresolvedVariables.addAll(fsMaybe.get().unresolvedVariables());
+
+		PartiallyResolvedConfiguration<C> partial = new PartiallyResolvedConfiguration<>(result, unresolvedVariables);
+		if (!reasonAggregator.hasReason())
+			return Maybe.complete(partial);
+
+		return Maybe.incomplete(partial, reasonAggregator.get());
+	}
+
+	public <C extends GenericEntity> Maybe<PartiallyResolvedConfiguration<C>> staticConfigPartiallyReasoned(EntityType<C> configType) {
+		return staticConfigPartiallyReasoned(configType, "");
 	}
 
 	// load from all possible sources and merge
@@ -356,6 +408,20 @@ public class ModeledYamlConfiguration implements ModeledConfiguration {
 		return listToEntities(configType, "classpath", sortedEpEntries, e -> e.url.openStream(), e -> e.url.toString());
 	}
 
+	private Maybe<PartialConfigEntries> readCpConfigPartially(EntityType<?> configType, String useCase) {
+		if (classpathIndex == null)
+			return Maybe.complete(new PartialConfigEntries(emptyList(), Set.of()));
+
+		String prefix = classpathConfPath + configFilePrefix(configType, useCase);
+		List<ClasspathEntry> cpEntries = classpathIndex.forPrefix(prefix);
+
+		if (cpEntries.isEmpty())
+			return Maybe.complete(new PartialConfigEntries(emptyList(), Set.of()));
+
+		List<ClasspathEntry> sortedCpEntries = ConfigurationEntrySorter.sortClasspathEntries(cpEntries);
+		return listToEntitiesPartially(configType, "classpath", sortedCpEntries, e -> e.url.openStream(), e -> e.url.toString());
+	}
+
 	// FileSystem
 
 	private Maybe<List<ConfigEntry>> readFsConfig(EntityType<?> configType, String useCase) {
@@ -371,6 +437,21 @@ public class ModeledYamlConfiguration implements ModeledConfiguration {
 		List<File> sortedFiles = ConfigurationEntrySorter.sortFiles(files);
 
 		return listToEntities(configType, "conf directory [" + configFolder.getPath() + "]", //
+				sortedFiles, f -> new BufferedInputStream(new FileInputStream(f)), File::getAbsolutePath);
+	}
+
+	private Maybe<PartialConfigEntries> readFsConfigPartially(EntityType<?> configType, String useCase) {
+		if (configFolder == null)
+			return Maybe.complete(new PartialConfigEntries(emptyList(), Set.of()));
+
+		String prefix = configFilePrefix(configType, useCase);
+		List<File> files = findConfigFiles(configFolder, prefix);
+
+		if (files.isEmpty())
+			return Maybe.complete(new PartialConfigEntries(emptyList(), Set.of()));
+
+		List<File> sortedFiles = ConfigurationEntrySorter.sortFiles(files);
+		return listToEntitiesPartially(configType, "conf directory [" + configFolder.getPath() + "]", //
 				sortedFiles, f -> new BufferedInputStream(new FileInputStream(f)), File::getAbsolutePath);
 	}
 
@@ -414,6 +495,37 @@ public class ModeledYamlConfiguration implements ModeledConfiguration {
 			return reasonAggregator.get().asMaybe();
 		else
 			return Maybe.complete(result);
+	}
+
+	private <C extends GenericEntity, E> Maybe<PartialConfigEntries> listToEntitiesPartially( //
+			EntityType<C> configType, String configSource, List<E> entries, //
+			CheckedFunction<E, InputStream, IOException> inputStreamProvider, Function<E, String> originProvider) {
+
+		var reasonAggregator = Reasons.aggregatorForceWrap(() -> ConfigurationError.create("Error while partially loading config from " + configSource));
+
+		List<ConfigEntry> result = newList();
+		Set<String> unresolvedVariables = new LinkedHashSet<>();
+		for (E entry : entries) {
+			Maybe<PartiallyResolvedConfiguration<C>> configMaybe = new ModeledYamlConfigurationLoader() //
+					.virtualEnvironment(virtualEnvironment) //
+					.variableResolverReasoned(propertyLookup) //
+					.absentifyMissingProperties(true) //
+					.loadConfigPartially(configType, () -> inputStreamProvider.apply(entry));
+
+			if (configMaybe.isSatisfied()) {
+				PartiallyResolvedConfiguration<C> partial = configMaybe.get();
+				result.add(new ConfigEntry(partial.configuration(), originProvider.apply(entry)));
+				unresolvedVariables.addAll(partial.unresolvedVariables());
+			} else {
+				reasonAggregator.accept(configMaybe.whyUnsatisfied());
+			}
+		}
+
+		PartialConfigEntries partialEntries = new PartialConfigEntries(result, unresolvedVariables);
+		if (reasonAggregator.hasReason())
+			return Maybe.incomplete(partialEntries, reasonAggregator.get());
+
+		return Maybe.complete(partialEntries);
 	}
 
 	//


### PR DESCRIPTION
Adds the neutral configuration import model and partial modeled-YAML read required for build-time assembly while preserving strict runtime behavior.\n\nEvidence: modeled-yaml-config-test passes after rebase on origin/main.