### PR TITLE
Canonicalize legacy Windows classpath indices

### DIFF
--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/index/ClasspathIndexTest.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/index/ClasspathIndexTest.java
@@ -2,6 +2,7 @@ package com.braintribe.gm.config.yaml.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -9,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,6 +75,36 @@ public class ClasspathIndexTest {
 		assertThat(entries.get(0).path).isEqualTo("HICONIC-CONF/example.yaml");
 		assertThat(entries.get(0).origin).isEqualTo("example-configuration");
 		assertThat(entries.get(0).url.getProtocol()).isEqualTo("file");
+	}
+
+	@Test
+	public void loadsLegacyWindowsClasspathIndex() throws Exception {
+		Path archive = temporaryFolder.newFile("windows-index.jar").toPath();
+		try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(archive))) {
+			writeZipEntry(out, "META-INF/classpath-index.txt", "HICONIC-CONF\\example.yaml\n");
+			writeZipEntry(out, "HICONIC-CONF/example.yaml", "example: true\n");
+		}
+
+		try (URLClassLoader classLoader = new URLClassLoader(new java.net.URL[] { archive.toUri().toURL() }, null)) {
+			List<ClasspathEntry> entries = new ClasspathIndex(classLoader).all();
+
+			assertThat(entries).hasSize(1);
+			assertThat(entries.get(0).path).isEqualTo("HICONIC-CONF/example.yaml");
+		}
+	}
+
+	@Test
+	public void loadsLegacyWindowsFilesystemIndex() throws Exception {
+		Path root = temporaryFolder.newFolder("windows-filesystem-index").toPath();
+		Path artifact = root.resolve("example-configuration-1.0");
+		Path config = artifact.resolve("HICONIC-CONF/example.yaml");
+		writeFilesystemArtifact(artifact, "example-configuration", "HICONIC-CONF\\example.yaml\n",
+				Map.of(config, "example: true\n"));
+
+		List<ClasspathEntry> entries = new ClasspathIndex(root).all();
+
+		assertThat(entries).hasSize(1);
+		assertThat(entries.get(0).path).isEqualTo("HICONIC-CONF/example.yaml");
 	}
 
 	@Test
@@ -257,6 +290,12 @@ public class ClasspathIndexTest {
 			Files.createDirectories(resource.getKey().getParent());
 			Files.writeString(resource.getKey(), resource.getValue(), StandardCharsets.UTF_8);
 		}
+	}
+
+	private void writeZipEntry(ZipOutputStream out, String name, String content) throws Exception {
+		out.putNextEntry(new ZipEntry(name));
+		out.write(content.getBytes(StandardCharsets.UTF_8));
+		out.closeEntry();
 	}
 
 }

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/index/ClasspathIndex.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/index/ClasspathIndex.java
@@ -194,6 +194,7 @@ public class ClasspathIndex {
 				line = line.trim();
 				if (line.isEmpty() || line.startsWith("#"))
 					continue;
+				line = canonicalResourcePath(line);
 
 				// From now on we consider line to be a path within given jar / artifact
 				Enumeration<URL> files = classLoader.getResources(line);
@@ -319,6 +320,7 @@ public class ClasspathIndex {
 				line = line.trim();
 				if (line.isEmpty() || line.startsWith("#"))
 					continue;
+				line = canonicalResourcePath(line);
 				if (source.excludes(line))
 					continue;
 
@@ -333,6 +335,10 @@ public class ClasspathIndex {
 		} catch (IOException e) {
 			throw new UncheckedIOException("Error while reading filesystem classpath index: " + index, e);
 		}
+	}
+
+	private static String canonicalResourcePath(String path) {
+		return path.replace('\\', '/');
 	}
 
 	private String filesystemOrigin(Path artifactRoot) {


### PR DESCRIPTION
Normalize backslash-separated classpath resource paths in both direct classpath and assembled filesystem index readers. This complements canonical index generation and keeps already built Windows artifacts usable at runtime. Includes regression tests for both sources.