### PR TITLE
mix

### DIFF
--- a/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl/DbLocking_MultiThread_Test.java
+++ b/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl/DbLocking_MultiThread_Test.java
@@ -81,6 +81,34 @@ public class DbLocking_MultiThread_Test extends AbstractDbLockingTestBase {
 		assertThat(wasConcurrent.value).isFalse();
 	}
 
+	/** Per {@link Lock#lock()} contract the method is not interruptible - it must keep waiting and only restore the interrupt status at the end. */
+	@Test(timeout = TIMEOUT_MS)
+	public void testLockIsNotInterruptible() throws Exception {
+		Lock holderLock = newRandomReentrantLock().writeLock();
+		holderLock.lock();
+
+		Lock waiterLock = newRandomReentrantLock().writeLock();
+		var interruptedAfterLock = new Box<Boolean>();
+
+		Thread waiter = new Thread(() -> {
+			waiterLock.lock(); // must survive the interrupt below and keep waiting
+			interruptedAfterLock.value = Thread.currentThread().isInterrupted();
+			waiterLock.unlock();
+		});
+		waiter.start();
+
+		// let the waiter block on the lock, then interrupt it
+		Thread.sleep(300);
+		waiter.interrupt();
+		// give the waiter a chance to (wrongly) die on the interrupt before we release the lock
+		Thread.sleep(100);
+
+		holderLock.unlock();
+		waiter.join();
+
+		assertThat(interruptedAfterLock.value).as("lock() must survive an interrupt, acquire the lock and restore the interrupt status").isTrue();
+	}
+
 	// #############################################
 	// ## . . . . . . . . Helpers . . . . . . . . ##
 	// #############################################

--- a/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl/DbLocking_SingleThread_Test.java
+++ b/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl/DbLocking_SingleThread_Test.java
@@ -104,7 +104,7 @@ public class DbLocking_SingleThread_Test extends AbstractDbLockingTestBase {
 	}
 
 	@Test(timeout = TIMEOUT_MS)
-	public void readIstReentrant() {
+	public void readIsReentrant() {
 		readLock.lock();
 		assertCanLock(readLock);
 		readLock.unlock();

--- a/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl/DbLocking_SingleThread_Test.java
+++ b/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl/DbLocking_SingleThread_Test.java
@@ -80,6 +80,7 @@ public class DbLocking_SingleThread_Test extends AbstractDbLockingTestBase {
 	public void writeIsNotReentrant() throws InterruptedException {
 		writeLock.lock();
 		assertThat(writeLock.tryLock(1, TimeUnit.SECONDS)).isFalse();
+		assertThat(writeLock.tryLock(1, TimeUnit.SECONDS)).isFalse();
 		writeLock.unlock();
 
 		// can lock again

--- a/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl/DbLocking_StaleLease_Test.java
+++ b/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl/DbLocking_StaleLease_Test.java
@@ -1,0 +1,152 @@
+// ============================================================================
+// Copyright BRAINTRIBE TECHNOLOGY GMBH, Austria, 2002-2022
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package com.braintribe.model.processing.locking.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.ResultSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.Lock;
+
+import org.junit.Test;
+
+import com.braintribe.common.db.DbVendor;
+import com.braintribe.provider.Box;
+import com.braintribe.util.jdbc.JdbcTools;
+
+/**
+ * Tests for {@link DbLocking} behavior when a lock's lease is lost, i.e. its row is deleted (and possibly re-created) by another node after the lease
+ * expired, while the original holder still believes it holds the lock.
+ * <p>
+ * The lease loss is simulated by deleting the lock row directly via SQL - exactly what another node's {@code deleteLockIfExpired} does.
+ *
+ * @author peter.gazdik
+ */
+public class DbLocking_StaleLease_Test extends AbstractDbLockingTestBase {
+
+	public DbLocking_StaleLease_Test(DbVendor vendor) {
+		super(vendor);
+	}
+
+	/**
+	 * Scenario: two threads share the same lock instance (normal j.u.c. usage - lock handle stored in a field).
+	 * <ol>
+	 * <li>Thread R1 acquires the read lock (incarnation 1 of the lock row).
+	 * <li>The lease is lost: another node deletes the expired row.
+	 * <li>The main thread acquires the read lock via the same instance (incarnation 2) and is now the legitimate holder.
+	 * <li>R1 unlocks. Its acquisition belongs to the deleted incarnation 1, so this must NOT release (delete from DB) the main thread's lock.
+	 * </ol>
+	 * With the shared mutable {@code rwLock.created} field, R1's unlock uses incarnation 2's {@code created} timestamp and deletes the main thread's
+	 * row - a writer can then acquire the lock while the main thread is still inside its read-locked section.
+	 */
+	@Test(timeout = TIMEOUT_MS)
+	public void staleUnlockMustNotReleaseNewIncarnation() throws Exception {
+		Lock readLock = newReentrantLock().readLock();
+
+		CountDownLatch r1Acquired = new CountDownLatch(1);
+		CountDownLatch r1MayUnlock = new CountDownLatch(1);
+		CountDownLatch r1Unlocked = new CountDownLatch(1);
+
+		Thread r1 = new Thread(() -> {
+			readLock.lock();
+			r1Acquired.countDown();
+			try {
+				r1MayUnlock.await();
+				readLock.unlock();
+			} catch (Exception e) {
+				// A stale unlock is allowed to complain, it just must not release the other holder's lock
+			} finally {
+				r1Unlocked.countDown();
+			}
+		});
+		r1.start();
+		r1Acquired.await();
+
+		simulateLeaseLoss();
+
+		// make sure incarnation 2 gets a different 'created' timestamp
+		Thread.sleep(50);
+
+		// main thread becomes the legitimate holder, via the same lock instance
+		assertThat(readLock.tryLock()).isTrue();
+
+		// Original bug: R1 would unlock and delete the row, thus the test later for lockRowCount would fail, as the number would be 0
+		r1MayUnlock.countDown();
+		r1Unlocked.await();
+		r1.join();
+
+		assertThat(lockRowCount()).as("Stale unlock released the new legitimate holder's lock").isEqualTo(1);
+
+		// ... and mutual exclusion must still hold: a writer must not be able to acquire
+		Lock writeLock = locking.forIdentifier(LOCK_ID).writeLock();
+		assertThat(writeLock.tryLock()).as("Writer acquired the lock while a reader still holds it").isFalse();
+
+		readLock.unlock();
+	}
+
+	/**
+	 * If a thread re-acquires a lock it already holds, but the underlying row belongs to a different incarnation (lease was lost and the row deleted
+	 * or re-created in the meantime), the implementation must not silently acquire a fresh lock - nested unlocks would then over-release it. It must
+	 * throw instead, as mutual exclusion was already violated and it cannot safely continue.
+	 */
+	@Test(timeout = TIMEOUT_MS)
+	public void reacquireAfterLeaseLossThrows() throws Exception {
+		Lock readLock = newReentrantLock().readLock();
+
+		readLock.lock();
+
+		simulateLeaseLoss();
+
+		// make sure a possible new incarnation would get a different 'created' timestamp
+		Thread.sleep(50);
+
+		assertThatThrownBy(readLock::tryLock, "Re-entering a lock whose lease was lost must fail loudly, not silently acquire a fresh lock") //
+				.isInstanceOf(IllegalStateException.class);
+	}
+
+	/** Analogous to {@link java.util.concurrent.locks.ReentrantReadWriteLock}: unlock by a thread that doesn't hold the lock is a caller bug. */
+	@Test(timeout = TIMEOUT_MS)
+	public void unlockWithoutHoldingThrowsIllegalMonitorState() {
+		Lock readLock = newReentrantLock().readLock();
+
+		assertThatThrownBy(readLock::unlock, "unlock() by a thread that does not hold the lock must throw") //
+				.isInstanceOf(IllegalMonitorStateException.class);
+	}
+
+	// #############################################
+	// ## . . . . . . . . Helpers . . . . . . . . ##
+	// #############################################
+
+	/** Deletes the lock row, exactly like another node's {@code deleteLockIfExpired} would after the lease expired. */
+	private void simulateLeaseLoss() {
+		JdbcTools.withStatement(dataSource, () -> "Simulating lease expiration + cleanup by another node", s -> {
+			s.executeUpdate("delete from " + DbLocking.DB_TABLE_NAME);
+		});
+	}
+
+	private int lockRowCount() {
+		Box<Integer> count = Box.of(0);
+		JdbcTools.withStatement(dataSource, () -> "Counting lock rows", s -> {
+			try (ResultSet rs = s.executeQuery("select count(*) from " + DbLocking.DB_TABLE_NAME + " where id = '" + LOCK_ID + "'")) {
+				rs.next();
+				count.value = rs.getInt(1);
+			}
+		});
+		return count.value;
+	}
+
+}

--- a/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl_weird/DbLockingRemoteTest.java
+++ b/gm-db-locking-test/src/com/braintribe/model/processing/locking/db/impl_weird/DbLockingRemoteTest.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import com.braintribe.common.db.DbVendor;
@@ -54,7 +53,8 @@ public class DbLockingRemoteTest {
 	// ##################################################################################################################
 	public static final DbVendor REMOTE_TEST_DB_VENDOR = DbVendor.postgres;
 
-	@Test
+	// Uncomment to run
+	// @Test
 	@Category(VerySlow.class)
 	public void testRemoteJvmsWithoutFailProbability() throws Exception {
 
@@ -82,7 +82,8 @@ public class DbLockingRemoteTest {
 		}
 	}
 
-	@Test
+	// Uncomment to run
+	// @Test
 	@Category(VerySlow.class)
 	public void testRemoteJvmsWithFailProbability() throws Exception {
 

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLockRefresher.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLockRefresher.java
@@ -18,9 +18,9 @@ package com.braintribe.model.processing.locking.db.impl;
 import static com.braintribe.utils.lcd.CollectionTools2.newList;
 
 import java.sql.Timestamp;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.braintribe.model.processing.locking.db.impl.DbLocking.DbRwLock;
 import com.braintribe.util.jdbc.JdbcTools;
@@ -35,20 +35,26 @@ import com.braintribe.utils.CollectionTools;
 
 	private final DbLocking dbLocking;
 
-	private final List<DbRwLock> s_locks = newList();
+	/* We update the row by id and timestamp to ensure we only ever refresh rows for locks we acquired, but not newer rows of another owner which
+	 * could have been acquired if we lost connection to DB and our lock expired. */
+	private record LockToRefresh(String id, Timestamp created) {
+		// empty
+	}
+
+	private final List<LockToRefresh> s_locks = newList();
 	private volatile int nLocks = 0;
 
 	public DbLockRefresher(DbLocking dbLocking) {
 		this.dbLocking = dbLocking;
 	}
 
-	public synchronized void startRefreshing(DbRwLock rwLock) {
-		s_locks.add(rwLock);
+	public synchronized void startRefreshing(DbRwLock lock, Timestamp created) {
+		s_locks.add(new LockToRefresh(lock.id, created));
 		nLocks++;
 	}
 
-	public synchronized void stopRefreshing(DbRwLock rwLock) {
-		s_locks.remove(rwLock);
+	public synchronized void stopRefreshing(DbRwLock lock, Timestamp created) {
+		s_locks.remove(new LockToRefresh(lock.id, created));
 		nLocks--;
 	}
 
@@ -56,44 +62,43 @@ import com.braintribe.utils.CollectionTools;
 		if (nLocks == 0)
 			return;
 
-		List<DbRwLock> locksToRefresh = locksToRefresh();
+		List<LockToRefresh> locksToRefresh = locksToRefresh();
 		if (locksToRefresh.isEmpty())
 			return;
 
 		refresh(locksToRefresh);
 	}
 
-	private synchronized List<DbRwLock> locksToRefresh() {
+	private synchronized List<LockToRefresh> locksToRefresh() {
 		return newList(s_locks);
 	}
 
-	private void refresh(List<DbRwLock> locksToRefresh) {
-		Set<String> lockIds = locksToRefresh.stream() //
-				.map(dbRwLock -> dbRwLock.id) //
-				.collect(Collectors.toSet());
+	private void refresh(List<LockToRefresh> locksToRefresh) {
+		// dedup - the same incarnation may be held by multiple threads
+		Set<LockToRefresh> locks = new HashSet<>(locksToRefresh);
 
 		long current = System.currentTimeMillis();
 		long expires = current + dbLocking.lockExpirationInMs;
 
 		Timestamp expiresTs = new Timestamp(expires);
 
-		List<List<String>> lockIdBatches = CollectionTools.split(lockIds, UPDATE_BATCH_SIZE);
+		List<List<LockToRefresh>> lockBatches = CollectionTools.split(locks, UPDATE_BATCH_SIZE);
 
-		JdbcTools.withConnection(dbLocking.dataSource, true, () -> "Refreshing locks " + lockIds, c -> {
+		String sql = "update " + DbLocking.DB_TABLE_NAME + " set expires = ? where id = ? and created = ?";
 
-			for (List<String> lockIdBatch : lockIdBatches) {
-				String sql = "update " + DbLocking.DB_TABLE_NAME + " set expires = ? where id in " + JdbcTools.questionMarks(lockIdBatch.size());
+		JdbcTools.withConnection(dbLocking.dataSource, true, () -> "Refreshing " + locks.size() + " locks", c -> {
 
-				JdbcTools.withPreparedStatement(c, sql, () -> "", ps -> {
-					ps.setTimestamp(1, expiresTs);
-
-					int i = 2;
-					for (String lockId : lockIdBatch)
-						ps.setString(i++, lockId);
-
-					ps.executeUpdate();
-				});
-			}
+			JdbcTools.withPreparedStatement(c, sql, () -> "", ps -> {
+				for (List<LockToRefresh> lockBatch : lockBatches) {
+					for (LockToRefresh lock : lockBatch) {
+						ps.setTimestamp(1, expiresTs);
+						ps.setString(2, lock.id());
+						ps.setTimestamp(3, lock.created());
+						ps.addBatch();
+					}
+					ps.executeBatch();
+				}
+			});
 
 		});
 	}

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLockRefresher.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLockRefresher.java
@@ -96,6 +96,10 @@ import com.braintribe.utils.CollectionTools;
 						ps.setTimestamp(3, lock.created());
 						ps.addBatch();
 					}
+					// TODO once LockStats is implemented, use the update counts (index-aligned with lockBatch) to detect lost leases early:
+					// a count of exactly 0 for an entry that is still registered in s_locks (recheck after the batch, as it may have been unlocked
+					// since our snapshot) means its lease was lost while held - warn + report via LockStats. Note that some drivers return
+					// Statement.SUCCESS_NO_INFO (-2) instead of real counts - only an exact 0 is a signal.
 					ps.executeBatch();
 				}
 			});

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -102,6 +102,8 @@ public class DbLocking implements Locking, LifecycleAware {
 	public static final int DEFAULT_POLL_INTERVAL_MS = 100;
 	public static final int DEFAULT_LOCK_EXPIRATION_MS = 5 * 60 * 1000;
 
+	private static final long NANOS_PER_MS = 1_000_000L;
+
 	/* package */ DataSource dataSource;
 	/* package */ JdbcDialect dialect;
 
@@ -109,7 +111,7 @@ public class DbLocking implements Locking, LifecycleAware {
 
 	private Supplier<MessagingSession> messagingSessionProvider;
 
-	private long pollIntervalInMillies = DEFAULT_POLL_INTERVAL_MS;
+	private long pollIntervalInNanos = DEFAULT_POLL_INTERVAL_MS * NANOS_PER_MS;
 	/* package */ long lockExpirationInMs = DEFAULT_LOCK_EXPIRATION_MS;
 
 	private int[] unlockRetryDelaysMs = { 500, 1000, 5000 };
@@ -138,7 +140,7 @@ public class DbLocking implements Locking, LifecycleAware {
 	 * <p>
 	 * Default value is {@value #DEFAULT_POLL_INTERVAL_MS} 
 	 */
-	@Configurable public void setPollIntervalInMillies(int pollIntervalInMillies) { this.pollIntervalInMillies = pollIntervalInMillies; }
+	@Configurable public void setPollIntervalInMillies(int pollIntervalInMillies) { this.pollIntervalInNanos = pollIntervalInMillies * NANOS_PER_MS; }
 	@Configurable public void setLockExpirationInSecs(int lockExpirationInSecs) { this.lockExpirationInMs = 1000L * lockExpirationInSecs; }
 
 	/**
@@ -417,7 +419,7 @@ public class DbLocking implements Locking, LifecycleAware {
 			try {
 				while (true) {
 					try {
-						if (tryLockMs(Long.MAX_VALUE))
+						if (tryLockNanos(Long.MAX_VALUE))
 							return;
 					} catch (InterruptedException e) {
 						log.debug("Non interruptible lock() call internally caught an InterruptedException, will continue waiting.");
@@ -435,16 +437,16 @@ public class DbLocking implements Locking, LifecycleAware {
 			if (Thread.interrupted())
 				throw new InterruptedException();
 
-			if (tryLockMs(Long.MAX_VALUE))
+			if (tryLockNanos(Long.MAX_VALUE))
 				return;
 		}
 
 		@Override
 		public boolean tryLock() {
 			try {
-				return tryLockMs(0);
+				return tryLockNanos(0);
 			} catch (InterruptedException e) {
-				// Not reachable with 0ms timeout (we never reach the waiting), but just in case
+				// Not reachable with 0 timeout (we never reach the waiting), but just in case
 				Thread.currentThread().interrupt();
 				return false;
 			}
@@ -452,14 +454,16 @@ public class DbLocking implements Locking, LifecycleAware {
 
 		@Override
 		public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
-			return tryLockMs(unit.toMillis(time));
+			// toNanos saturates at Long.MAX_VALUE on overflow, which is fine - that means "forever" (~292 years) below
+			return tryLockNanos(unit.toNanos(time));
 		}
 
-		private boolean tryLockMs(long tryMs) throws InterruptedException {
-			long now = System.currentTimeMillis();
-			long tryUntil = now + tryMs;
-			if (tryUntil < 0)
-				tryUntil = Long.MAX_VALUE;
+		private boolean tryLockNanos(long tryNanos) throws InterruptedException {
+			// The remaining time is counted down using the monotonic System.nanoTime(), so wall-clock adjustments (NTP etc.) can neither shorten
+			// nor extend the wait. We track it as a count-down rather than a deadline, because nanoTime values have an arbitrary origin and only
+			// their differences are meaningful. Long.MAX_VALUE (~292 years) effectively means "wait forever".
+			long remainingNanos = tryNanos;
+			long lastNanoTime = System.nanoTime();
 
 			Thread currentThread = Thread.currentThread();
 			String oldThreadName = currentThread.getName();
@@ -502,13 +506,16 @@ public class DbLocking implements Locking, LifecycleAware {
 						}
 					}
 
-					long millisLeft = tryUntil - System.currentTimeMillis();
-					if (millisLeft <= 0) {
+					long now = System.nanoTime();
+					remainingNanos -= now - lastNanoTime;
+					lastNanoTime = now;
+
+					if (remainingNanos <= 0) {
 						if (hasWriteLocking)
 							releaseWriteLocking();
 						return false;
 					}
-					waitBeforeTryLockAgain(millisLeft);
+					waitBeforeTryLockAgain(remainingNanos);
 				}
 
 			} catch (InterruptedException e) {
@@ -692,13 +699,13 @@ public class DbLocking implements Locking, LifecycleAware {
 			return result.value;
 		}
 
-		private void waitBeforeTryLockAgain(long millisLeft) throws InterruptedException {
-			long waitMillies = Math.min(millisLeft, pollIntervalInMillies);
+		private void waitBeforeTryLockAgain(long nanosLeft) throws InterruptedException {
+			long waitNanos = Math.min(nanosLeft, pollIntervalInNanos);
 
 			CountDownLatch unlockLatch = registerUnlockWaiter(rwLock.id);
 			try {
 				// an unlock notification that arrives right after registering still wakes us up - a counted-down latch doesn't wait at all
-				unlockLatch.await(waitMillies, TimeUnit.MILLISECONDS);
+				unlockLatch.await(waitNanos, TimeUnit.NANOSECONDS);
 			} finally {
 				unregisterUnlockWaiter(rwLock.id, unlockLatch);
 			}

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -486,7 +486,7 @@ public class DbLocking implements Locking, LifecycleAware {
 						});
 
 						if (successIndicator.value != null) {
-							refresher.startRefreshing(rwLock);
+							refresher.startRefreshing(rwLock, tlLockHoldInfo.get().created);
 							return true;
 						}
 					}
@@ -545,9 +545,9 @@ public class DbLocking implements Locking, LifecycleAware {
 			Timestamp expiresTs = new Timestamp(expires);
 
 			boolean result = tryInsert(c, currentTs, expiresTs);
-
 			if (result)
 				tlLockHoldInfo.set(new LockHoldInfo(currentTs));
+
 			return result;
 		}
 
@@ -609,7 +609,7 @@ public class DbLocking implements Locking, LifecycleAware {
 					ps.setTimestamp(i++, expiresTs);
 					ps.setTimestamp(i++, currentTs);
 					ps.setString(i++, rwLock.caller);
-					ps.setString(i++, "machine"); // TODO machine
+					ps.setString(i++, nodeId);
 
 					ps.executeUpdate();
 				});
@@ -710,7 +710,7 @@ public class DbLocking implements Locking, LifecycleAware {
 				throw new IllegalMonitorStateException("Attempt to unlock a lock, not locked by current thread: " + lockContext());
 
 			if (lockHoldInfo.count == 1)
-				refresher.stopRefreshing(rwLock);
+				refresher.stopRefreshing(rwLock, lockHoldInfo.created);
 
 			try {
 				var lockReleasedIndicator = new Box<Boolean>();

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -91,7 +92,6 @@ import com.braintribe.utils.lcd.NullSafe;
  * <p>
  * {@code unlock()} by a thread that holds no lock throws an {@link IllegalMonitorStateException}, re-entering a lock whose lease was lost throws an
  * {@link IllegalStateException}.
- *
  */
 public class DbLocking implements Locking, LifecycleAware {
 
@@ -100,9 +100,13 @@ public class DbLocking implements Locking, LifecycleAware {
 	public static final String DB_TABLE_NAME = "hc_locking";
 
 	public static final int DEFAULT_POLL_INTERVAL_MS = 100;
+	public static final int DEFAULT_MAX_POLL_INTERVAL_MS = 5000;
 	public static final int DEFAULT_LOCK_EXPIRATION_MS = 5 * 60 * 1000;
 
 	private static final long NANOS_PER_MS = 1_000_000L;
+
+	// the longer current lock has been held, the less frequently we poll: interval = lock age / this ratio (within min/max limits).
+	private static final long LOCK_AGE_TO_POLL_INTERVAL_RATIO = 10;
 
 	/* package */ DataSource dataSource;
 	/* package */ JdbcDialect dialect;
@@ -112,6 +116,7 @@ public class DbLocking implements Locking, LifecycleAware {
 	private Supplier<MessagingSession> messagingSessionProvider;
 
 	private long pollIntervalInNanos = DEFAULT_POLL_INTERVAL_MS * NANOS_PER_MS;
+	private long maxPollIntervalInNanos = DEFAULT_MAX_POLL_INTERVAL_MS * NANOS_PER_MS;
 	/* package */ long lockExpirationInMs = DEFAULT_LOCK_EXPIRATION_MS;
 
 	private int[] unlockRetryDelaysMs = { 500, 1000, 5000 };
@@ -136,11 +141,21 @@ public class DbLocking implements Locking, LifecycleAware {
 	@Configurable public void setAutoUpdateSchema(boolean autoUpdateSchema) { this.autoUpdateSchema = autoUpdateSchema; }
 
 	/**
-	 * Determines the re-try interval to acquire a lock in case the first try wasn't successful.  
+	 * Determines the minimum re-try interval to acquire a lock in case the first try wasn't successful. The actual interval grows with the age of
+	 * the currently held lock (see {@link #setMaxPollIntervalInMillies(int)}) and is jittered to avoid waiters polling in lockstep.
 	 * <p>
-	 * Default value is {@value #DEFAULT_POLL_INTERVAL_MS} 
+	 * Default value is {@value #DEFAULT_POLL_INTERVAL_MS}
 	 */
 	@Configurable public void setPollIntervalInMillies(int pollIntervalInMillies) { this.pollIntervalInNanos = pollIntervalInMillies * NANOS_PER_MS; }
+
+	/**
+	 * Upper limit for the re-try interval: the longer the current lock has already been held, the less likely it is to be released in the very next
+	 * moment, so waiters poll less frequently (lock age / {@value #LOCK_AGE_TO_POLL_INTERVAL_RATIO}), but never less frequently than this limit.
+	 * <p>
+	 * Default value is {@value #DEFAULT_MAX_POLL_INTERVAL_MS}
+	 */
+	@Configurable public void setMaxPollIntervalInMillies(int maxPollIntervalInMillies) { this.maxPollIntervalInNanos = maxPollIntervalInMillies * NANOS_PER_MS; }
+
 	@Configurable public void setLockExpirationInSecs(int lockExpirationInSecs) { this.lockExpirationInMs = 1000L * lockExpirationInSecs; }
 
 	/**
@@ -389,6 +404,11 @@ public class DbLocking implements Locking, LifecycleAware {
 		}
 	}
 
+	/** Snapshot of the lock row as observed by a waiter while trying to acquire the lock. */
+	private record LockRow(String reentranceId, Timestamp expires, Timestamp created) {
+		// empty
+	}
+
 	private class DistributedLock implements Lock {
 		private final DbRwLock rwLock;
 		private final String reentranceId;
@@ -469,8 +489,12 @@ public class DbLocking implements Locking, LifecycleAware {
 			String oldThreadName = currentThread.getName();
 			currentThread.setName(oldThreadName + " > waiting for lock " + rwLock.id);
 			boolean hasWriteLocking = false;
+
+			// On first attempt, and upon unlock notification, be optimistic and insert right away
+			// after failed insert, do a select to assess the situation
+			boolean tryInsertFirst = true;
+
 			try {
-				var successIndicator = new Box<Boolean>();
 				while (true) {
 					if (!hasWriteLocking)
 						hasWriteLocking = acquireWriteLocking();
@@ -479,43 +503,43 @@ public class DbLocking implements Locking, LifecycleAware {
 						LockHoldInfo lockHoldInfo = tlLockHoldInfo.get();
 						if (lockHoldInfo != null)
 							return reEnter(lockHoldInfo);
+					}
 
-						JdbcTools.withConnection(dataSource, true, () -> "Trying to acquire lock " + rwLock.id, connection -> {
-							if (tryInsert(connection)) {
-								successIndicator.value = Boolean.TRUE;
-								return;
+					// register before DB attempt so an unlock notification is not lost
+					CountDownLatch unlockLatch = registerUnlockWaiter(rwLock.id);
+					try {
+						var observedRow = new Box<LockRow>();
+
+						if (hasWriteLocking) {
+							boolean insertFirst = tryInsertFirst;
+							var acquired = new Box<Boolean>();
+							JdbcTools.withConnection(dataSource, true, () -> "Trying to acquire lock " + rwLock.id, connection -> {
+								acquired.value = tryAcquire(connection, insertFirst, observedRow);
+							});
+
+							if (Boolean.TRUE.equals(acquired.value)) {
+								refresher.startRefreshing(rwLock, tlLockHoldInfo.get().created);
+								return true;
 							}
-
-							if (tryIncreaseCount(connection)) {
-								successIndicator.value = Boolean.TRUE;
-								return;
-							}
-
-							if (!deleteLockIfExpired(connection))
-								return;
-
-							if (tryInsert(connection)) {
-								successIndicator.value = Boolean.TRUE;
-								return;
-							}
-						});
-
-						if (successIndicator.value != null) {
-							refresher.startRefreshing(rwLock, tlLockHoldInfo.get().created);
-							return true;
 						}
-					}
 
-					long now = System.nanoTime();
-					remainingNanos -= now - lastNanoTime;
-					lastNanoTime = now;
+						long now = System.nanoTime();
+						remainingNanos -= now - lastNanoTime;
+						lastNanoTime = now;
 
-					if (remainingNanos <= 0) {
-						if (hasWriteLocking)
-							releaseWriteLocking();
-						return false;
+						if (remainingNanos <= 0) {
+							if (hasWriteLocking)
+								releaseWriteLocking();
+							return false;
+						}
+
+						long waitNanos = Math.min(remainingNanos, nextPollIntervalNanos(observedRow.value));
+						// an unlock notification that arrived since registering still wakes us up - a counted-down latch doesn't wait at all
+						tryInsertFirst = unlockLatch.await(waitNanos, TimeUnit.NANOSECONDS);
+
+					} finally {
+						unregisterUnlockWaiter(rwLock.id, unlockLatch);
 					}
-					waitBeforeTryLockAgain(remainingNanos);
 				}
 
 			} catch (InterruptedException e) {
@@ -552,6 +576,60 @@ public class DbLocking implements Locking, LifecycleAware {
 
 			hold.count++;
 			return true;
+		}
+
+		/**
+		 * Single acquisition attempt. If insertFirst, optimistically tries an insert (the row probably doesn't exist); otherwise it starts with a
+		 * select of the current row state and only attempts the write that state calls for - this way a failed attempt of a blocked waiter costs just
+		 * one cheap single-row select.
+		 * <p>
+		 * If not acquired, the observed row (null if there was none) is stored in observedRow and drives the length of the subsequent wait.
+		 */
+		private boolean tryAcquire(Connection c, boolean insertFirst, Box<LockRow> observedRow) throws Exception {
+			if (insertFirst && tryInsert(c))
+				return true;
+
+			LockRow row = queryLockRow(c);
+			observedRow.value = row;
+
+			if (row == null)
+				// no row (or it disappeared since our failed insert) - grab it
+				return tryInsert(c);
+
+			if (reentranceId.equals(row.reentranceId())) {
+				// a lock with our reentranceId exists (e.g. another read lock) - join it by incrementing its count
+				if (tryChangeCount(c, row.created(), +1)) {
+					tlLockHoldInfo.set(new LockHoldInfo(row.created()));
+					return true;
+				}
+				// the row changed between our select and update - try again next round
+				return false;
+			}
+
+			if (isExpired(row) && deleteLockIfExpired(c))
+				return tryInsert(c);
+
+			return false;
+		}
+
+		private boolean isExpired(LockRow row) {
+			return row.expires().getTime() <= System.currentTimeMillis();
+		}
+
+		private LockRow queryLockRow(Connection c) {
+			String query = "select reentranceId, expires, created from " + DB_TABLE_NAME + " where id = ?";
+
+			var result = new Box<LockRow>();
+			JdbcTools.withPreparedStatement(c, query, () -> "Querying lock row with id " + rwLock.id, ps -> {
+				ps.setString(1, rwLock.id);
+
+				try (ResultSet rs = ps.executeQuery()) {
+					if (rs.next())
+						result.value = new LockRow(rs.getString(1), rs.getTimestamp(2), rs.getTimestamp(3));
+				}
+			});
+
+			return result.value;
 		}
 
 		// id, expires, created, caller, machine
@@ -648,15 +726,6 @@ public class DbLocking implements Locking, LifecycleAware {
 			}
 		}
 
-		private boolean tryIncreaseCount(Connection c) {
-			Timestamp created = queryCreatedTime(c);
-			if (created == null || !tryChangeCount(c, created, +1))
-				return false;
-
-			tlLockHoldInfo.set(new LockHoldInfo(created));
-			return true;
-		}
-
 		// Throws wrapped SQLExceptions!!!
 		private boolean tryChangeCount(Connection c, Timestamp created, int diff) {
 			long current = System.currentTimeMillis();
@@ -680,35 +749,36 @@ public class DbLocking implements Locking, LifecycleAware {
 			return updated.value > 0;
 		}
 
-		private Timestamp queryCreatedTime(Connection c) {
-			String query = "select created from " + DB_TABLE_NAME + " where id = ? and reentranceId = ?";
-			List<Object> params = asList(rwLock.id, reentranceId);
+		/**
+		 * Wait time depends on how long current lock row was held - the longer, the less likely it will be released soon, within limits.
+		 * <p>
+		 * Result is jittered to +-50% so that concurrent waiters don't poll in lock-step.
+		 * <p>
+		 * But if the lock is about to expire, we wake up right expiration.
+		 */
+		private long nextPollIntervalNanos(LockRow row) {
+			if (row == null)
+				return jittered(pollIntervalInNanos);
 
-			var result = new Box<Timestamp>();
-			JdbcTools.withPreparedStatement(c, query, params, () -> "Querying lock if expired with id " + rwLock.id, ps -> {
-				ps.setString(1, rwLock.id);
-				ps.setString(2, reentranceId);
+			long now = System.currentTimeMillis();
 
-				try (ResultSet rs = ps.executeQuery()) {
-					if (rs.next()) {
-						result.value = rs.getTimestamp(1);
-					}
-				}
-			});
+			long lockAgeMs = now - row.created().getTime(); // may even be negative with cross-node clock skew
+			long ageBasedNanos = lockAgeMs / LOCK_AGE_TO_POLL_INTERVAL_RATIO * NANOS_PER_MS;
+			long baseNanos = Math.min(maxPollIntervalInNanos, Math.max(pollIntervalInNanos, ageBasedNanos));
 
-			return result.value;
+			long jitteredNanos = jittered(baseNanos);
+
+			// +1 ms so we wake up just after the expiration, not just before it
+			long untilExpirationNanos = (row.expires().getTime() - now + 1) * NANOS_PER_MS;
+			if (untilExpirationNanos > 0)
+				return Math.min(jitteredNanos, untilExpirationNanos);
+
+			return jitteredNanos;
 		}
 
-		private void waitBeforeTryLockAgain(long nanosLeft) throws InterruptedException {
-			long waitNanos = Math.min(nanosLeft, pollIntervalInNanos);
-
-			CountDownLatch unlockLatch = registerUnlockWaiter(rwLock.id);
-			try {
-				// an unlock notification that arrives right after registering still wakes us up - a counted-down latch doesn't wait at all
-				unlockLatch.await(waitNanos, TimeUnit.NANOSECONDS);
-			} finally {
-				unregisterUnlockWaiter(rwLock.id, unlockLatch);
-			}
+		/** Random value between 50% and 150% of nanos */
+		private long jittered(long nanos) {
+			return nanos / 2 + ThreadLocalRandom.current().nextLong(nanos + 1);
 		}
 
 		@Override

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -24,16 +24,14 @@ import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.sql.Timestamp;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import javax.sql.DataSource;
 
@@ -88,8 +86,8 @@ public class DbLocking implements Locking, LifecycleAware {
 
 	private Supplier<MessagingSession> messagingSessionProvider;
 
-	private int pollIntervalInMillies = DEFAULT_POLL_INTERVAL_MS;
-	/* package */ int lockExpirationInMs = DEFAULT_LOCK_EXPIRATION_MS;
+	private long pollIntervalInMillies = DEFAULT_POLL_INTERVAL_MS;
+	/* package */ long lockExpirationInMs = DEFAULT_LOCK_EXPIRATION_MS;
 
 	private boolean autoUpdateSchema = true;
 
@@ -118,7 +116,7 @@ public class DbLocking implements Locking, LifecycleAware {
 	 * Default value is {@value #DEFAULT_POLL_INTERVAL_MS} 
 	 */
 	@Configurable public void setPollIntervalInMillies(int pollIntervalInMillies) { this.pollIntervalInMillies = pollIntervalInMillies; }
-	@Configurable public void setLockExpirationInSecs(int lockExpirationInSecs) { this.lockExpirationInMs = 1000 * lockExpirationInSecs; }
+	@Configurable public void setLockExpirationInSecs(int lockExpirationInSecs) { this.lockExpirationInMs = 1000L * lockExpirationInSecs; }
 
 	@Configurable public void setTopicExpiration(long topicExpiration) { this.topicExpiration = topicExpiration; }
 	@Configurable public void setTopicName(String topicName) { this.topicName = topicName; }
@@ -130,10 +128,8 @@ public class DbLocking implements Locking, LifecycleAware {
 		if (autoUpdateSchema)
 			try {
 				ensureLocksTable();
-				// We start the ensuring of the indices in a separate thread to not slow down
-				// the startup procedure. We do not need the indices right away, so it's
-				// ok to wait a bit.
-				Thread.ofVirtual().start(this::ensureIndices);
+
+				Thread.ofVirtual().start(this::removeObsoleteIndices);
 
 			} catch (Exception e) {
 				throw new RuntimeException("Error while ensuring " + DB_TABLE_NAME + " table used by Locking", e);
@@ -147,48 +143,32 @@ public class DbLocking implements Locking, LifecycleAware {
 		}
 	}
 
-	private void ensureIndices() {
+	// 28.7.2026: we used to create these, they serve no purpose, let's make sure to remove them to improve efficiency
+	private void removeObsoleteIndices() {
 		try (Connection connection = dataSource.getConnection()) {
-			log.debug(() -> "Ensuring indices on " + DB_TABLE_NAME);
+			log.debug(() -> "Dropping indices on " + DB_TABLE_NAME);
 
-			List<String> columns = List.of("reentranceId", "count", "expires", "created");
+			List<String> indexNames = Stream.of("reentranceId", "count", "expires", "created") //
+					.map(col -> (DB_TABLE_NAME + "_" + col + "_idx").toLowerCase()) //
+					.toList();
 
-			Map<String, String> indexPairs = new HashMap<>();
-			//@formatter:off
-			columns.stream().forEach(col -> {
-				String indexName = (DB_TABLE_NAME + "_" + col + "_idx").toLowerCase();
-				indexPairs.put(indexName, col);
-			});
-			//@formatter:on
-
-			Set<String> existingInstances = JdbcTools.indicesExist(connection, DB_TABLE_NAME, indexPairs.keySet());
-			if (existingInstances.size() == indexPairs.size()) {
-				// Indices already exist.
+			Set<String> existingInstances = JdbcTools.indicesExist(connection, DB_TABLE_NAME, indexNames);
+			if (existingInstances.isEmpty())
 				return;
-			}
-
-			Set<String> indices = new HashSet<>(indexPairs.keySet());
-			indices.removeAll(existingInstances);
-			if (indices.isEmpty()) {
-				return;
-			}
 
 			try (Statement statement = connection.createStatement()) {
-
-				for (String indexName : indices) {
-					String col = indexPairs.get(indexName);
-
-					String sql = "CREATE INDEX " + indexName + " ON " + DB_TABLE_NAME + " (" + col + ");";
-					log.debug(() -> "Creating index with statement: " + sql);
+				for (String indexName : indexNames) {
+					String sql = "DROP INDEX IF EXISTS " + indexName + ";";
+					log.info("Deleting index with statement: " + sql);
 					statement.executeUpdate(sql);
-					log.debug(() -> "Successfully created index on column " + col + " in table " + DB_TABLE_NAME);
+					log.info("Successfully deleted index " + indexName + " in table " + DB_TABLE_NAME);
 				}
 
 			} catch (Exception e) {
-				log.debug(() -> "Error while trying to ensure indices: " + e.getMessage(), e);
+				log.warn("Error while trying to drop indices: " + e.getMessage(), e);
 			}
 		} catch (Exception e) {
-			log.debug(() -> "Error while connecting to the DB to ensure indices: " + e.getMessage(), e);
+			log.warn("Error while connecting to the DB to drop indices: " + e.getMessage(), e);
 		}
 	}
 
@@ -278,7 +258,7 @@ public class DbLocking implements Locking, LifecycleAware {
 		return WALKER.walk(framesStream -> framesStream //
 				.dropWhile(f -> isFrameworkFrame(f)) //
 				.findFirst() //
-				.map(DbLocking::format) //
+				.map(DbLocking::printCaller) //
 				.orElse("unknown") //
 		);
 	}
@@ -306,11 +286,12 @@ public class DbLocking implements Locking, LifecycleAware {
 		Class<?> c = frame.getDeclaringClass();
 
 		return Locking.class.isAssignableFrom(c) || // covers the deploy proxy
+				ReentrableLocking.class.isAssignableFrom(c) || // covers
 				c == DbLocking.class || //
 				c.getName().startsWith("tribefire.proxy.deploy.Locking");
 	}
 
-	private static String format(StackFrame f) {
+	private static String printCaller(StackFrame f) {
 		String className = f.getClassName();
 		int i = className.lastIndexOf('.');
 		if (i > 0)

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -24,8 +24,11 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -347,35 +350,6 @@ public class DbLocking implements Locking, LifecycleAware {
 		} catch (Exception e) {
 			throw Exceptions.unchecked(e, "Could not generate MD5 of lock id " + id);
 		}
-	}
-
-	protected MessageConsumer listenForUnlockNotification(String id, Object monitor) {
-		DbLockingMsg msg = lazyMsg.get();
-		if (msg.messagingSession == null)
-			return null;
-
-		try {
-			MessageConsumer messageConsumer = msg.messagingSession.createMessageConsumer(msg.topic);
-			messageConsumer.setMessageListener(message -> onUnlockMessage(id, monitor, message));
-
-			return messageConsumer;
-
-		} catch (MessagingException e) {
-			log.error("error while adding message listener for a lock queue", e);
-			return null;
-		}
-	}
-
-	private void onUnlockMessage(String id, Object monitor, Message message) {
-		Object body = message.getBody();
-		if (!(body instanceof String))
-			return;
-
-		String lockId = (String) body;
-		if (lockId.equals(id))
-			synchronized (monitor) {
-				monitor.notify();
-			}
 	}
 
 	/**
@@ -718,26 +692,14 @@ public class DbLocking implements Locking, LifecycleAware {
 		}
 
 		private void waitBeforeTryLockAgain(long millisLeft) throws InterruptedException {
-			// TODO use CountDownLatch instead? This could not-catch a notification
-			Object monitor = new Object();
+			long waitMillies = Math.min(millisLeft, pollIntervalInMillies);
 
-			MessageConsumer consumer = listenForUnlockNotification(rwLock.id, monitor);
-
+			CountDownLatch unlockLatch = registerUnlockWaiter(rwLock.id);
 			try {
-				long waitMillies = Math.min(millisLeft, pollIntervalInMillies);
-
-				synchronized (monitor) {
-					monitor.wait(waitMillies);
-				}
-
+				// an unlock notification that arrives right after registering still wakes us up - a counted-down latch doesn't wait at all
+				unlockLatch.await(waitMillies, TimeUnit.MILLISECONDS);
 			} finally {
-				if (consumer != null) {
-					try {
-						consumer.close();
-					} catch (MessagingException e) {
-						log.error("error while closing message consumer", e);
-					}
-				}
+				unregisterUnlockWaiter(rwLock.id, unlockLatch);
 			}
 		}
 
@@ -820,15 +782,15 @@ public class DbLocking implements Locking, LifecycleAware {
 
 	}
 
-	private void notifyUnlock(String id) {
+	private void notifyUnlock(String lockId) {
 		DbLockingMsg msg = lazyMsg.get();
-		if (msg.messagingSession != null && msg.messageProducer != null) {
+		if (msg.msgSession != null && msg.msgProducer != null) {
 			try {
-				Message message = msg.messagingSession.createMessage();
-				message.setBody(id);
+				Message message = msg.msgSession.createMessage();
+				message.setBody(lockId);
 				message.setTimeToLive(topicExpiration);
 
-				msg.messageProducer.sendMessage(message);
+				msg.msgProducer.sendMessage(message);
 
 			} catch (MessagingException e) {
 				log.error("error while producing message for a lock", e);
@@ -838,17 +800,21 @@ public class DbLocking implements Locking, LifecycleAware {
 
 	class DbLockingMsg implements AutoCloseable {
 		private Topic topic;
-		private MessageProducer messageProducer;
-		private MessagingSession messagingSession;
+		private MessageProducer msgProducer;
+		/** Shared consumer for all lock waiters of this instance, dispatching unlock notifications via {@link DbLocking#onUnlockMessage(Message)}. */
+		private MessageConsumer msgConsumer;
+		private MessagingSession msgSession;
 
 		public DbLockingMsg() {
 			if (messagingSessionProvider == null)
 				return;
 
 			try {
-				messagingSession = messagingSessionProvider.get();
-				topic = messagingSession.createTopic(topicName);
-				messageProducer = messagingSession.createMessageProducer(topic);
+				msgSession = messagingSessionProvider.get();
+				topic = msgSession.createTopic(topicName);
+				msgProducer = msgSession.createMessageProducer(topic);
+				msgConsumer = msgSession.createMessageConsumer(topic);
+				msgConsumer.setMessageListener(DbLocking.this::onUnlockMessage);
 
 			} catch (MessagingException e) {
 				log.error("error while retrieving messaging components", e);
@@ -858,20 +824,80 @@ public class DbLocking implements Locking, LifecycleAware {
 
 		@Override
 		public void close() {
-			if (messageProducer != null)
+			if (msgProducer != null)
 				try {
-					messageProducer.close();
+					msgProducer.close();
 				} catch (Exception e) {
-					log.warn("error while closing message producer");
+					log.warn("error while closing message producer", e);
+				} finally {
+					msgProducer = null;
 				}
 
-			if (messagingSession != null)
+			if (msgConsumer != null)
 				try {
-					messagingSession.close();
+					msgConsumer.close();
+				} catch (Exception e) {
+					log.warn("error while closing message consumer", e);
+				} finally {
+					msgConsumer = null;
+				}
+
+			if (msgSession != null)
+				try {
+					msgSession.close();
 				} catch (MessagingException e) {
-					log.warn("error while closing messaging session");
+					log.warn("error while closing messaging session", e);
+				} finally {
+					msgSession = null;
 				}
 		}
+	}
+
+	// ##############################################
+	// ## . . . . Waiting for unlock . . . . . . .##
+	// ##############################################
+
+	/** Threads waiting for a lock, per lock id, to be woken up by an unlock notification. See {@link #registerUnlockWaiter(String)}. */
+	private final Map<String, Set<CountDownLatch>> lockIdToWaiterCdls = new ConcurrentHashMap<>();
+
+	/**
+	 * Registers a latch that is counted down when an unlock notification for given lock id arrives via the shared {@link DbLockingMsg#msgConsumer
+	 * message consumer}. The caller must {@link #unregisterUnlockWaiter(String, CountDownLatch) unregister} it in a finally block.
+	 * <p>
+	 * If messaging is not configured, the latch is never counted down and waiting on it degrades to pure polling.
+	 */
+	private CountDownLatch registerUnlockWaiter(String lockId) {
+		lazyMsg.get(); // ensures the shared consumer is listening (if messaging is configured at all)
+
+		CountDownLatch latch = new CountDownLatch(1);
+		lockIdToWaiterCdls.compute(lockId, (id, latches) -> {
+			Set<CountDownLatch> result = latches == null ? ConcurrentHashMap.newKeySet() : latches;
+			result.add(latch);
+			return result;
+		});
+
+		return latch;
+	}
+
+	private void unregisterUnlockWaiter(String lockId, CountDownLatch latch) {
+		lockIdToWaiterCdls.compute(lockId, (id, latches) -> {
+			if (latches == null)
+				return null;
+
+			latches.remove(latch);
+			return latches.isEmpty() ? null : latches;
+		});
+	}
+
+	private void onUnlockMessage(Message message) {
+		Object body = message.getBody();
+		if (!(body instanceof String))
+			return;
+
+		String lockId = (String) body;
+		Set<CountDownLatch> latches = lockIdToWaiterCdls.get(lockId);
+		if (latches != null)
+			latches.forEach(CountDownLatch::countDown);
 	}
 
 }

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -97,6 +97,8 @@ public class DbLocking implements Locking, LifecycleAware {
 	/* package */ DataSource dataSource;
 	/* package */ JdbcDialect dialect;
 
+	private String nodeId = "machine";
+
 	private Supplier<MessagingSession> messagingSessionProvider;
 
 	private long pollIntervalInMillies = DEFAULT_POLL_INTERVAL_MS;
@@ -121,6 +123,7 @@ public class DbLocking implements Locking, LifecycleAware {
 	}
 
 	// @formatter:off
+	@Configurable public void setNodeId(String nodeId) { this.nodeId = nodeId; }
 	@Configurable public void setAutoUpdateSchema(boolean autoUpdateSchema) { this.autoUpdateSchema = autoUpdateSchema; }
 
 	/**
@@ -611,7 +614,7 @@ public class DbLocking implements Locking, LifecycleAware {
 				ps.setTimestamp(i++, expiresTs);
 				ps.setTimestamp(i++, currentTs);
 				ps.setString(i++, rwLock.caller);
-				ps.setString(i++, "machine"); // TODO machine
+				ps.setString(i++, nodeId);
 
 				updated.value = ps.executeUpdate();
 			});

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -63,21 +64,26 @@ import com.braintribe.utils.lcd.NullSafe;
  * For each {@link Lock}, acquired e.g. via {@link #forIdentifier(String)} (or similar methods), an entry is created with a certain expiration date.
  * This expiration date is the current time plus the configured {@link #setLockExpirationInSecs(int)}.
  * 
- * <h3>Thread ownership</h3>
- *
- * Like with {@link java.util.concurrent.locks.ReentrantReadWriteLock}, a lock must be released by the same thread that acquired it. Each acquisition
- * remembers (per thread) which incarnation of the lock row it acquired, so that a holder whose lease was lost (lock expired and was cleaned up or
- * taken over by another node) cannot accidentally release a newer lock of another owner. {@code unlock()} by a thread that holds no acquisition
- * throws an {@link IllegalMonitorStateException}, re-entering a lock whose lease was lost throws an {@link IllegalStateException}.
- *
  * <h3>Updating expiration dates automatically</h3>
  * 
+ * <b>IMPORTANT:</b> This needs to be configured externally!
+ * <p>
  * This expiration date should be updated automatically, ideally as a scheduled task. It should be configured externally, and the update is performed
  * by calling {@link #refreshLockedLocks()}.
  * <p>
  * Should a node fail to update the expiration date, another node will consider such entry as stale and will try to acquire the lock again.
  * <p>
  * For this reason it is advised to configure the refreshing interval significantly smaller than the lock expiration, for example one half of it.
+ * 
+ * <h3>Thread ownership</h3>
+ *
+ * Like with {@link ReentrantReadWriteLock}, a lock must be released by the same thread that acquired it. Each acquisition remembers (per thread)
+ * which incarnation of the lock row it acquired, so that a lock-owner whose lease was lost (lock expired and was cleaned up or taken over by another
+ * node) cannot accidentally release a newer lock of another owner.
+ * <p>
+ * {@code unlock()} by a thread that holds no lock throws an {@link IllegalMonitorStateException}, re-entering a lock whose lease was lost throws an
+ * {@link IllegalStateException}.
+ *
  */
 public class DbLocking implements Locking, LifecycleAware {
 

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -21,7 +21,6 @@ import java.lang.StackWalker.StackFrame;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.List;
@@ -655,16 +654,19 @@ public class DbLocking implements Locking, LifecycleAware {
 				return true;
 
 			} catch (Exception e) {
-				if (e.getCause() instanceof SQLSyntaxErrorException)
-					throw new RuntimeException(e);
+				SQLException sqlE = JdbcTools.unwrapSqlException(e);
+				if (sqlE != null) {
+					String sqlState = sqlE.getSQLState();
+					// indicates a constraint violation, e.g. duplicate key, which means a row with given lock id already exists
+					boolean isIntegrityConstraintViolation = sqlState != null && sqlState.startsWith("23");
+					if (isIntegrityConstraintViolation)
+						return false;
+				}
 
-				// Exception is expected here if a row already exists
-				log.trace(() -> "Lock not obtained due to " + e.getClass().getSimpleName() + ""
-						+ (e.getMessage() != null ? ": " + e.getMessage() : ""));
-
-				return false;
+				throw e;
 			}
 		}
+
 		private boolean tryIncreaseCount(Connection c) {
 			Timestamp created = queryCreatedTime(c);
 			if (created == null || !tryChangeCount(c, created, +1))

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -111,6 +112,8 @@ public class DbLocking implements Locking, LifecycleAware {
 	private long pollIntervalInMillies = DEFAULT_POLL_INTERVAL_MS;
 	/* package */ long lockExpirationInMs = DEFAULT_LOCK_EXPIRATION_MS;
 
+	private int[] unlockRetryDelaysMs = { 500, 1000, 5000 };
+
 	private boolean autoUpdateSchema = true;
 
 	private String topicName = "hc-locking";
@@ -137,6 +140,14 @@ public class DbLocking implements Locking, LifecycleAware {
 	 */
 	@Configurable public void setPollIntervalInMillies(int pollIntervalInMillies) { this.pollIntervalInMillies = pollIntervalInMillies; }
 	@Configurable public void setLockExpirationInSecs(int lockExpirationInSecs) { this.lockExpirationInMs = 1000L * lockExpirationInSecs; }
+
+	/**
+	 * Delays (in milliseconds) between retries of the DB update that releases a lock, should it fail with an error (e.g. connection loss). One retry
+	 * is attempted per array entry. Without a successful release the lock stays blocked for everyone until its lease expires, hence the retries.
+	 * <p>
+	 * Default value is {500, 1000, 5000}
+	 */
+	@Configurable public void setUnlockRetryDelaysMs(int[] unlockRetryDelaysMs) { this.unlockRetryDelaysMs = NullSafe.nonNull(unlockRetryDelaysMs, "unlockRetryDelaysMs"); }
 
 	@Configurable public void setTopicExpiration(long topicExpiration) { this.topicExpiration = topicExpiration; }
 	@Configurable public void setTopicName(String topicName) { this.topicName = topicName; }
@@ -254,9 +265,9 @@ public class DbLocking implements Locking, LifecycleAware {
 	}
 
 	private ReentrableReadWriteLock forIdentifierAndReentranceId(String id, String reentranceId) {
-		String tuncId = truncateTo240Chars(id);
+		String truncId = truncateTo240Chars(id);
 		String caller = identifyCaller();
-		return new DbRwLock(tuncId, reentranceId, caller);
+		return new DbRwLock(truncId, reentranceId, caller);
 	}
 
 	private static final StackWalker WALKER = StackWalker.getInstance(Set.of(StackWalker.Option.RETAIN_CLASS_REFERENCE), 8);
@@ -639,6 +650,7 @@ public class DbLocking implements Locking, LifecycleAware {
 			return true;
 		}
 
+		// Throws wrapped SQLExceptions!!!
 		private boolean tryChangeCount(Connection c, Timestamp created, int diff) {
 			long current = System.currentTimeMillis();
 			long expires = current + lockExpirationInMs;
@@ -648,28 +660,17 @@ public class DbLocking implements Locking, LifecycleAware {
 			String query = "update " + DB_TABLE_NAME + " set count = count + ?, expires = ? where id = ? and reentranceId = ? and created = ?";
 
 			var updated = new Box<Integer>();
-			try {
-				JdbcTools.withPreparedStatement(c, query, () -> "updating count for lock with id " + rwLock.id, ps -> {
-					ps.setInt(1, diff);
-					ps.setTimestamp(2, expiresTs);
-					ps.setString(3, rwLock.id);
-					ps.setString(4, reentranceId);
-					ps.setTimestamp(5, created);
+			JdbcTools.withPreparedStatement(c, query, () -> "updating count for lock with id " + rwLock.id, ps -> {
+				ps.setInt(1, diff);
+				ps.setTimestamp(2, expiresTs);
+				ps.setString(3, rwLock.id);
+				ps.setString(4, reentranceId);
+				ps.setTimestamp(5, created);
 
-					updated.value = ps.executeUpdate();
-				});
+				updated.value = ps.executeUpdate();
+			});
 
-				if (updated.value == 0)
-					return false;
-
-				return true;
-
-			} catch (Exception e) {
-				log.debug(() -> "Lock not obtained due to " + e.getClass().getSimpleName() + ""
-						+ (e.getMessage() != null ? ": " + e.getMessage() : ""));
-
-				return false;
-			}
+			return updated.value > 0;
 		}
 
 		private Timestamp queryCreatedTime(Connection c) {
@@ -713,27 +714,101 @@ public class DbLocking implements Locking, LifecycleAware {
 				refresher.stopRefreshing(rwLock, lockHoldInfo.created);
 
 			try {
-				var lockReleasedIndicator = new Box<Boolean>();
-				JdbcTools.withConnection(dataSource, true, () -> "Deleting unlocked lock " + rwLock.id, connection -> {
-					if (tryChangeCount(connection, lockHoldInfo.created, -1))
-						lockReleasedIndicator.value = deleteLockIfExpired(connection);
-					else
-						log.warn("Lock lease was lost while held (the lock expired and was released or taken over by another owner) - mutual "
-								+ "exclusion may have been violated during the critical section." + lockContext());
-				});
+				boolean lockReleased = releaseLockInDb(lockHoldInfo);
 
 				// only notify waiters if the lock row was actually deleted - as long as it exists (count > 0) they cannot acquire it anyway
-				if (Boolean.TRUE.equals(lockReleasedIndicator.value))
+				if (lockReleased)
 					notifyUnlock(rwLock.id);
 
 			} catch (Exception e) {
-				log.warn("Error while releasing lock " + rwLock.id, e);
+				log.warn("Error while releasing lock " + rwLock.id + ", it will stay blocked for everyone until its lease expires.", e);
 
 			} finally {
 				if (--lockHoldInfo.count == 0)
 					tlLockHoldInfo.remove();
 				if (isWriteLocking)
 					releaseWriteLocking();
+			}
+		}
+
+		/**
+		 * Releases this thread's hold in the DB and says whether the lock row was actually deleted (i.e. waiters can now acquire the lock).
+		 * <p>
+		 * DB errors are retried as per {@link #setUnlockRetryDelaysMs(int[])}, to really try not to leave behind a stale lock.
+		 */
+		private boolean releaseLockInDb(LockHoldInfo lockHoldInfo) throws Exception {
+			// Common case: we are the sole holder - delete the row outright, with a single statement.
+			if (deleteLockIfSoleHolder(lockHoldInfo))
+				return true;
+
+			// Other holders exist - just decrement the count.
+			if (!decrementLockCount(lockHoldInfo)) {
+				// Our row incarnation is gone: the lease was lost, or (rarely) a delete retry above reached the DB but reporting its result failed.
+				log.warn("Lock lease was lost while held (the lock expired and was released or taken over by another owner) - mutual "
+						+ "exclusion may have been violated during the critical section." + lockContext());
+				return false;
+			}
+
+			// In case a concurrent unlock brought the count down to 1 between our two statements above, our decrement left the row at 0 - delete it.
+			return retryingOnDbErrors(() -> {
+				var deleted = new Box<Boolean>();
+				JdbcTools.withConnection(dataSource, true, () -> "Deleting released lock " + rwLock.id, connection -> {
+					deleted.value = deleteLockIfExpired(connection);
+				});
+
+				return Boolean.TRUE.equals(deleted.value);
+			});
+		}
+
+		private boolean deleteLockIfSoleHolder(LockHoldInfo lockHoldInfo) throws Exception {
+			String query = "delete from " + DB_TABLE_NAME + " where id = ? and reentranceId = ? and created = ? and count = 1";
+
+			return retryingOnDbErrors(() -> {
+				var deleted = new Box<Integer>();
+				JdbcTools.withConnection(dataSource, true, () -> "Deleting unlocked lock " + rwLock.id, connection -> {
+					JdbcTools.withPreparedStatement(connection, query, () -> "deleting entry for lock with id " + rwLock.id, ps -> {
+						ps.setString(1, rwLock.id);
+						ps.setString(2, reentranceId);
+						ps.setTimestamp(3, lockHoldInfo.created);
+
+						deleted.value = ps.executeUpdate();
+					});
+				});
+
+				return deleted.value > 0;
+			});
+		}
+
+		private boolean decrementLockCount(LockHoldInfo lockHoldInfo) throws Exception {
+			var decremented = new Box<Boolean>();
+			JdbcTools.withConnection(dataSource, true, () -> "Decrementing count of lock " + rwLock.id, connection -> {
+				decremented.value = tryChangeCount(connection, lockHoldInfo.created, -1);
+			});
+
+			return Boolean.TRUE.equals(decremented.value);
+		}
+
+		private boolean retryingOnDbErrors(Callable<Boolean> dbTask) throws Exception {
+			int nextRetry = 0;
+
+			while (true) {
+				try {
+					return dbTask.call();
+
+				} catch (Exception e) {
+					if (nextRetry >= unlockRetryDelaysMs.length)
+						throw e;
+
+					long delayMs = unlockRetryDelaysMs[nextRetry++];
+					log.warn("Error while releasing lock " + rwLock.id + ", retrying in " + delayMs + " ms.", e);
+
+					try {
+						Thread.sleep(delayMs);
+					} catch (InterruptedException ie) {
+						Thread.currentThread().interrupt();
+						throw e; // interrupted - give up retrying
+					}
+				}
 			}
 		}
 

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -448,9 +448,9 @@ public class DbLocking implements Locking, LifecycleAware {
 			Thread currentThread = Thread.currentThread();
 			String oldThreadName = currentThread.getName();
 			currentThread.setName(oldThreadName + " > waiting for lock " + rwLock.id);
+			boolean hasWriteLocking = false;
 			try {
 				var successIndicator = new Box<Boolean>();
-				boolean hasWriteLocking = false;
 				while (true) {
 					if (!hasWriteLocking)
 						hasWriteLocking = acquireWriteLocking();
@@ -484,18 +484,21 @@ public class DbLocking implements Locking, LifecycleAware {
 
 					long millisLeft = tryUntil - System.currentTimeMillis();
 					if (millisLeft <= 0) {
-						releaseWriteLocking();
+						if (hasWriteLocking)
+							releaseWriteLocking();
 						return false;
 					}
 					waitBeforeTryLockAgain(millisLeft);
 				}
 
 			} catch (InterruptedException e) {
-				releaseWriteLocking();
+				if (hasWriteLocking)
+					releaseWriteLocking();
 				throw e;
 
 			} catch (Exception e) {
-				releaseWriteLocking();
+				if (hasWriteLocking)
+					releaseWriteLocking();
 				throw new RuntimeException("Could not get lock.", e);
 
 			} finally {
@@ -694,7 +697,8 @@ public class DbLocking implements Locking, LifecycleAware {
 			} catch (Exception e) {
 				log.warn("Error while releasing lock " + rwLock.id, e);
 			} finally {
-				releaseWriteLocking();
+				if (isWriteLocking)
+					releaseWriteLocking();
 			}
 		}
 

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -63,6 +63,13 @@ import com.braintribe.utils.lcd.NullSafe;
  * For each {@link Lock}, acquired e.g. via {@link #forIdentifier(String)} (or similar methods), an entry is created with a certain expiration date.
  * This expiration date is the current time plus the configured {@link #setLockExpirationInSecs(int)}.
  * 
+ * <h3>Thread ownership</h3>
+ *
+ * Like with {@link java.util.concurrent.locks.ReentrantReadWriteLock}, a lock must be released by the same thread that acquired it. Each acquisition
+ * remembers (per thread) which incarnation of the lock row it acquired, so that a holder whose lease was lost (lock expired and was cleaned up or
+ * taken over by another node) cannot accidentally release a newer lock of another owner. {@code unlock()} by a thread that holds no acquisition
+ * throws an {@link IllegalMonitorStateException}, re-entering a lock whose lease was lost throws an {@link IllegalStateException}.
+ *
  * <h3>Updating expiration dates automatically</h3>
  * 
  * This expiration date should be updated automatically, ideally as a scheduled task. It should be configured externally, and the update is performed
@@ -315,8 +322,6 @@ public class DbLocking implements Locking, LifecycleAware {
 		public final DistributedLock readLock;
 		public final DistributedLock writeLock;
 
-		public Timestamp created;
-
 		public DbRwLock(String id, String reentranceId, String caller) {
 			this.id = id;
 			this.caller = caller;
@@ -387,11 +392,31 @@ public class DbLocking implements Locking, LifecycleAware {
 	// ## . . . . . . . . . Lock . . . . . . . . . ##
 	// ##############################################
 
+	/**
+	 * Tracks one thread's hold on a {@link DistributedLock}: which incarnation of the lock row it acquired - a timestamp and how many times it
+	 * (re-)entered the lock.
+	 */
+	private static class LockHoldInfo {
+		final Timestamp created;
+		int count = 1;
+
+		LockHoldInfo(Timestamp created) {
+			this.created = created;
+		}
+	}
+
 	private class DistributedLock implements Lock {
 		private final DbRwLock rwLock;
 		private final String reentranceId;
 		private final boolean isWriteLock;
 		private volatile boolean isWriteLocking; // to make sure writeLock is not re-entrant
+
+		/**
+		 * This thread's hold on this lock, null if it doesn't hold it. Each acquisition remembers the {@code created} timestamp of the row
+		 * incarnation it acquired, and unlock only releases that exact incarnation. This implies lock and unlock must happen on the same thread, just
+		 * like with {@link java.util.concurrent.locks.ReentrantReadWriteLock}.
+		 */
+		private final ThreadLocal<LockHoldInfo> tlLockHoldInfo = new ThreadLocal<>();
 
 		public DistributedLock(DbRwLock rwLock, String reentranceId, boolean isWriteLock) {
 			this.rwLock = rwLock;
@@ -456,6 +481,10 @@ public class DbLocking implements Locking, LifecycleAware {
 						hasWriteLocking = acquireWriteLocking();
 
 					if (hasWriteLocking) {
+						LockHoldInfo lockHoldInfo = tlLockHoldInfo.get();
+						if (lockHoldInfo != null)
+							return reEnter(lockHoldInfo);
+
 						JdbcTools.withConnection(dataSource, true, () -> "Trying to acquire lock " + rwLock.id, connection -> {
 							if (tryInsert(connection)) {
 								successIndicator.value = Boolean.TRUE;
@@ -496,6 +525,12 @@ public class DbLocking implements Locking, LifecycleAware {
 					releaseWriteLocking();
 				throw e;
 
+			} catch (IllegalStateException e) {
+				// lost lease detected while re-entering - propagate as is
+				if (hasWriteLocking)
+					releaseWriteLocking();
+				throw e;
+
 			} catch (Exception e) {
 				if (hasWriteLocking)
 					releaseWriteLocking();
@@ -504,6 +539,21 @@ public class DbLocking implements Locking, LifecycleAware {
 			} finally {
 				currentThread.setName(oldThreadName);
 			}
+		}
+
+		/** This thread already holds the lock, so the only legitimate outcome is incrementing the count of our own row incarnation. */
+		private boolean reEnter(LockHoldInfo hold) {
+			var successIndicator = new Box<Boolean>();
+			JdbcTools.withConnection(dataSource, true, () -> "Re-entering lock " + rwLock.id, connection -> {
+				successIndicator.value = tryChangeCount(connection, hold.created, +1);
+			});
+
+			if (!Boolean.TRUE.equals(successIndicator.value))
+				throw new IllegalStateException("Cannot re-enter lock, even though it's already held by current thread. "
+						+ "Its lease was lost - the lock expired, probably due to some error with keeping it alive: " + lockContext());
+
+			hold.count++;
+			return true;
 		}
 
 		// id, expires, created, caller, machine
@@ -517,7 +567,7 @@ public class DbLocking implements Locking, LifecycleAware {
 			boolean result = tryInsert(c, currentTs, expiresTs);
 
 			if (result)
-				rwLock.created = currentTs;
+				tlLockHoldInfo.set(new LockHoldInfo(currentTs));
 			return result;
 		}
 
@@ -599,10 +649,10 @@ public class DbLocking implements Locking, LifecycleAware {
 		}
 		private boolean tryIncreaseCount(Connection c) {
 			Timestamp created = queryCreatedTime(c);
-			if (!tryChangeCount(c, created, +1))
+			if (created == null || !tryChangeCount(c, created, +1))
 				return false;
 
-			rwLock.created = created;
+			tlLockHoldInfo.set(new LockHoldInfo(created));
 			return true;
 		}
 
@@ -683,20 +733,30 @@ public class DbLocking implements Locking, LifecycleAware {
 		}
 		@Override
 		public void unlock() {
-			refresher.stopRefreshing(rwLock);
+			LockHoldInfo lockHoldInfo = tlLockHoldInfo.get();
+			if (lockHoldInfo == null)
+				throw new IllegalMonitorStateException("Attempt to unlock a lock, not locked by current thread: " + lockContext());
+
+			if (lockHoldInfo.count == 1)
+				refresher.stopRefreshing(rwLock);
 
 			try {
 				JdbcTools.withConnection(dataSource, true, () -> "Deleting unlocked lock " + rwLock.id, connection -> {
-					if (tryChangeCount(connection, rwLock.created, -1))
+					if (tryChangeCount(connection, lockHoldInfo.created, -1))
 						deleteLockIfExpired(connection);
+					else
+						log.warn("Lock lease was lost while held (the lock expired and was released or taken over by another owner) - mutual "
+								+ "exclusion may have been violated during the critical section." + lockContext());
 				});
 
 				notifyUnlock(rwLock.id);
-				return;
 
 			} catch (Exception e) {
 				log.warn("Error while releasing lock " + rwLock.id, e);
+
 			} finally {
+				if (--lockHoldInfo.count == 0)
+					tlLockHoldInfo.remove();
 				if (isWriteLocking)
 					releaseWriteLocking();
 			}

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -17,6 +17,7 @@ package com.braintribe.model.processing.locking.db.impl;
 
 import static com.braintribe.utils.lcd.CollectionTools2.asList;
 
+import java.lang.StackWalker.StackFrame;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -271,6 +272,17 @@ public class DbLocking implements Locking, LifecycleAware {
 		return new DbRwLock(tuncId, reentranceId, caller);
 	}
 
+	private static final StackWalker WALKER = StackWalker.getInstance(Set.of(StackWalker.Option.RETAIN_CLASS_REFERENCE), 8);
+
+	private String identifyCaller() {
+		return WALKER.walk(framesStream -> framesStream //
+				.dropWhile(f -> isFrameworkFrame(f)) //
+				.findFirst() //
+				.map(DbLocking::format) //
+				.orElse("unknown") //
+		);
+	}
+
 	/**
 	 * Stacktrace might have many different forms, but with no proxy the earliest possible caller position is 3.
 	 * 
@@ -284,31 +296,35 @@ public class DbLocking implements Locking, LifecycleAware {
 		 StackTraceElement[x]: >> Caller <<
 	 * }
 	 */
-	private String identifyCaller() {
-		int n = 3;
+	private static boolean isFrameworkFrame(StackFrame frame) {
+		// Old way using class names, not sure it's needed,
+		// String className = frame.getClassName();
+		// return className.startsWith(DbLocking.class.getName()) || //
+		// className.startsWith(Locking.class.getName()) || //
+		// className.startsWith("tribefire.proxy.deploy.Locking");
 
-		while (true) {
-			StackTraceElement stackTraceElement = Thread.currentThread().getStackTrace()[n++];
+		Class<?> c = frame.getDeclaringClass();
 
-			String className = stackTraceElement.getClassName();
-			if (className.startsWith(DbLocking.class.getName()) || className.startsWith(Locking.class.getName())
-					|| className.startsWith("tribefire.proxy.deploy.Locking"))
-				continue;
+		return Locking.class.isAssignableFrom(c) || // covers the deploy proxy
+				c == DbLocking.class || //
+				c.getName().startsWith("tribefire.proxy.deploy.Locking");
+	}
 
-			int lineNumber = stackTraceElement.getLineNumber();
-			String methodName = stackTraceElement.getMethodName();
+	private static String format(StackFrame f) {
+		String className = f.getClassName();
+		int i = className.lastIndexOf('.');
+		if (i > 0)
+			className = className.substring(i + 1);
 
-			int i = className.lastIndexOf(".");
-			if (i > 0)
-				className = className.substring(i + 1);
+		int lineNumber = f.getLineNumber();
+		String methodName = f.getMethodName();
 
-			String caller = className + '.' + methodName + '(' + (lineNumber >= 0 ? lineNumber : "") + ')';
-			if (caller.length() <= 240)
-				return caller;
+		String caller = className + '.' + methodName + ':' + (lineNumber >= 0 ? lineNumber : "-");
+		if (caller.length() <= 240)
+			return caller;
 
-			int len = caller.length();
-			return caller.substring(len - 240, len);
-		}
+		int len = caller.length();
+		return caller.substring(len - 240, len);
 	}
 
 	/* package */ class DbRwLock implements ReentrableReadWriteLock {
@@ -443,7 +459,6 @@ public class DbLocking implements Locking, LifecycleAware {
 		}
 
 		private boolean tryLockMs(long tryMs) throws InterruptedException {
-
 			long now = System.currentTimeMillis();
 			long tryUntil = now + tryMs;
 			if (tryUntil < 0)

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -436,14 +436,21 @@ public class DbLocking implements Locking, LifecycleAware {
 
 		@Override
 		public void lock() {
+			// per Lock.lock() contract this method is not interruptible - keep waiting and restore the interrupt status at the end
+			boolean interrupted = false;
 			try {
-				if (tryLockMs(Long.MAX_VALUE))
-					return;
-			} catch (InterruptedException e) {
-				// ignore as there is a special lock method that supports interruptibility
-				log.debug("non interruptible lock() call internally caught an InterruptedException");
-				Thread.currentThread().interrupt();
-				throw new RuntimeException("Thread was interrupted, cannot lock " + lockContext(), e);
+				while (true) {
+					try {
+						if (tryLockMs(Long.MAX_VALUE))
+							return;
+					} catch (InterruptedException e) {
+						log.debug("Non interruptible lock() call internally caught an InterruptedException, will continue waiting.");
+						interrupted = true;
+					}
+				}
+			} finally {
+				if (interrupted)
+					Thread.currentThread().interrupt();
 			}
 		}
 
@@ -461,6 +468,8 @@ public class DbLocking implements Locking, LifecycleAware {
 			try {
 				return tryLockMs(0);
 			} catch (InterruptedException e) {
+				// Not reachable with 0ms timeout (we never reach the waiting), but just in case
+				Thread.currentThread().interrupt();
 				return false;
 			}
 		}
@@ -737,6 +746,7 @@ public class DbLocking implements Locking, LifecycleAware {
 				}
 			}
 		}
+
 		@Override
 		public void unlock() {
 			LockHoldInfo lockHoldInfo = tlLockHoldInfo.get();
@@ -747,15 +757,18 @@ public class DbLocking implements Locking, LifecycleAware {
 				refresher.stopRefreshing(rwLock);
 
 			try {
+				var lockReleasedIndicator = new Box<Boolean>();
 				JdbcTools.withConnection(dataSource, true, () -> "Deleting unlocked lock " + rwLock.id, connection -> {
 					if (tryChangeCount(connection, lockHoldInfo.created, -1))
-						deleteLockIfExpired(connection);
+						lockReleasedIndicator.value = deleteLockIfExpired(connection);
 					else
 						log.warn("Lock lease was lost while held (the lock expired and was released or taken over by another owner) - mutual "
 								+ "exclusion may have been violated during the critical section." + lockContext());
 				});
 
-				notifyUnlock(rwLock.id);
+				// only notify waiters if the lock row was actually deleted - as long as it exists (count > 0) they cannot acquire it anyway
+				if (Boolean.TRUE.equals(lockReleasedIndicator.value))
+					notifyUnlock(rwLock.id);
 
 			} catch (Exception e) {
 				log.warn("Error while releasing lock " + rwLock.id, e);

--- a/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
+++ b/gm-db-locking/src/com/braintribe/model/processing/locking/db/impl/DbLocking.java
@@ -53,6 +53,7 @@ import com.braintribe.transport.messaging.api.MessagingSession;
 import com.braintribe.util.jdbc.JdbcTools;
 import com.braintribe.util.jdbc.dialect.JdbcDialect;
 import com.braintribe.utils.DigestGenerator;
+import com.braintribe.utils.lcd.Lazy;
 import com.braintribe.utils.lcd.NullSafe;
 
 /**
@@ -73,6 +74,10 @@ import com.braintribe.utils.lcd.NullSafe;
  * Should a node fail to update the expiration date, another node will consider such entry as stale and will try to acquire the lock again.
  * <p>
  * For this reason it is advised to configure the refreshing interval significantly smaller than the lock expiration, for example one half of it.
+ * 
+ * <h3>Fairness</h3>
+ * 
+ * This class does not support reader/writer fairness.
  * 
  * <h3>Thread ownership</h3>
  *
@@ -107,13 +112,10 @@ public class DbLocking implements Locking, LifecycleAware {
 
 	private String topicName = "hc-locking";
 	private long topicExpiration = 5000L;
-	private Topic topic;
-	private MessageProducer messageProducer;
-
-	protected boolean messagingInitialized = false;
-	private MessagingSession messagingSession;
 
 	private final DbLockRefresher refresher = new DbLockRefresher(this);
+
+	private final Lazy<DbLockingMsg> lazyMsg = new Lazy<>(DbLockingMsg::new);
 
 	@Required
 	public void setDataSource(DataSource dataSource) {
@@ -226,20 +228,7 @@ public class DbLocking implements Locking, LifecycleAware {
 
 	@Override
 	public void preDestroy() {
-		if (messageProducer != null) {
-			try {
-				messageProducer.close();
-			} catch (Exception e) {
-				log.warn("error while closing message producer");
-			}
-		}
-		if (messagingSession != null) {
-			try {
-				messagingSession.close();
-			} catch (MessagingException e) {
-				log.warn("error while closing messaging session");
-			}
-		}
+		lazyMsg.close();
 	}
 
 	@Override
@@ -361,12 +350,12 @@ public class DbLocking implements Locking, LifecycleAware {
 	}
 
 	protected MessageConsumer listenForUnlockNotification(String id, Object monitor) {
-		ensureMessagingInitialized();
-		if (messagingSession == null)
+		DbLockingMsg msg = lazyMsg.get();
+		if (msg.messagingSession == null)
 			return null;
 
 		try {
-			MessageConsumer messageConsumer = messagingSession.createMessageConsumer(topic);
+			MessageConsumer messageConsumer = msg.messagingSession.createMessageConsumer(msg.topic);
 			messageConsumer.setMessageListener(message -> onUnlockMessage(id, monitor, message));
 
 			return messageConsumer;
@@ -832,14 +821,14 @@ public class DbLocking implements Locking, LifecycleAware {
 	}
 
 	private void notifyUnlock(String id) {
-		ensureMessagingInitialized();
-		if (messagingSession != null && messageProducer != null) {
+		DbLockingMsg msg = lazyMsg.get();
+		if (msg.messagingSession != null && msg.messageProducer != null) {
 			try {
-				Message message = messagingSession.createMessage();
+				Message message = msg.messagingSession.createMessage();
 				message.setBody(id);
 				message.setTimeToLive(topicExpiration);
 
-				messageProducer.sendMessage(message);
+				msg.messageProducer.sendMessage(message);
 
 			} catch (MessagingException e) {
 				log.error("error while producing message for a lock", e);
@@ -847,22 +836,41 @@ public class DbLocking implements Locking, LifecycleAware {
 		}
 	}
 
-	private void ensureMessagingInitialized() {
-		if (messagingInitialized)
-			return;
+	class DbLockingMsg implements AutoCloseable {
+		private Topic topic;
+		private MessageProducer messageProducer;
+		private MessagingSession messagingSession;
 
-		messagingInitialized = true;
+		public DbLockingMsg() {
+			if (messagingSessionProvider == null)
+				return;
 
-		if (messagingSessionProvider == null)
-			return;
+			try {
+				messagingSession = messagingSessionProvider.get();
+				topic = messagingSession.createTopic(topicName);
+				messageProducer = messagingSession.createMessageProducer(topic);
 
-		try {
-			messagingSession = messagingSessionProvider.get();
-			topic = messagingSession.createTopic(topicName);
-			messageProducer = messagingSession.createMessageProducer(topic);
+			} catch (MessagingException e) {
+				log.error("error while retrieving messaging components", e);
+				close();
+			}
+		}
 
-		} catch (MessagingException e) {
-			log.error("error while retrieving messaging components", e);
+		@Override
+		public void close() {
+			if (messageProducer != null)
+				try {
+					messageProducer.close();
+				} catch (Exception e) {
+					log.warn("error while closing message producer");
+				}
+
+			if (messagingSession != null)
+				try {
+					messagingSession.close();
+				} catch (MessagingException e) {
+					log.warn("error while closing messaging session");
+				}
 		}
 	}
 

--- a/jdbc-messaging/src/com/braintribe/messaging/jdbc/JdbcMessageProducer.java
+++ b/jdbc-messaging/src/com/braintribe/messaging/jdbc/JdbcMessageProducer.java
@@ -55,7 +55,7 @@ public class JdbcMessageProducer extends JdbcAbstractMessageHandler implements M
 	@Override
 	public void sendMessage(Message message) throws MessagingException {
 		if (destination == null)
-			throw new UnsupportedOperationException("Cannot send message as no destination was assigned to the message producer at creation time");
+			throw new UnsupportedOperationException("Cannot send message as no default destination was assigned to the producer.");
 
 		sendMessage(message, destination);
 	}

--- a/jdbc-messaging/src/com/braintribe/messaging/jdbc/JdbcMessagingSession.java
+++ b/jdbc-messaging/src/com/braintribe/messaging/jdbc/JdbcMessagingSession.java
@@ -67,9 +67,8 @@ public class JdbcMessagingSession implements MessagingSession {
 	}
 
 	private void validateDestinationName(String name) throws MessagingException {
-		if (name == null || name.trim().isEmpty()) {
-			throw new MessagingException("Destination name [ " + name + " ] is not valid");
-		}
+		if (name == null || name.trim().isEmpty())
+			throw new MessagingException("Empty destination name [ " + name + " ] is not valid!");
 	}
 
 	@Override
@@ -78,7 +77,7 @@ public class JdbcMessagingSession implements MessagingSession {
 	}
 
 	@Override
-	public MessageProducer createMessageProducer(Destination destination) throws MessagingException {
+	public MessageProducer createMessageProducer(Destination destination) {
 		logger.debug(() -> "Creating message producer for destination: " + destination + ", name: "
 				+ (destination != null ? destination.getName() : "<null>"));
 
@@ -90,7 +89,7 @@ public class JdbcMessagingSession implements MessagingSession {
 	}
 
 	@Override
-	public MessageConsumer createMessageConsumer(Destination destination) throws MessagingException {
+	public MessageConsumer createMessageConsumer(Destination destination) {
 		NullSafe.nonNull(destination, "destination");
 
 		logger.debug(() -> "Creating message consumer for destination: " + destination);

--- a/jdbc-support/pom.xml
+++ b/jdbc-support/pom.xml
@@ -23,7 +23,8 @@ limitations under the License.
     <version>2.0.27</version>
     <properties>
         <archetype>library</archetype>
-    </properties>
+		<java.version>21</java.version>
+	</properties>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>

--- a/jdbc-support/src/com/braintribe/util/jdbc/JdbcTools.java
+++ b/jdbc-support/src/com/braintribe/util/jdbc/JdbcTools.java
@@ -17,6 +17,7 @@ package com.braintribe.util.jdbc;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collection;
@@ -169,6 +170,17 @@ public class JdbcTools {
 
 	public static String questionMarks(int times) {
 		return " (" + StringTools.repeat("?,", times).substring(0, 2 * times - 1) + ")";
+	}
+
+	/** Returns the first {@link SQLException} it encounters when examining givent {@link Throwable} and its causes. */
+	public static SQLException unwrapSqlException(Throwable t) {
+		while (t != null) {
+			if (t instanceof SQLException sqlE)
+				return sqlE;
+
+			t = t.getCause();
+		}
+		return null;
 	}
 
 }


### PR DESCRIPTION
- **JDBC Locking - optimizing caller determination**
- **JDBC Locking - removing obsolete indices**
- **JDBC Locking: fixing non-reentrance of write locks**
- **JDBC Locking: fixing various types of stale state issues**
- **JDBC Locking: javadoc**
- **JDBC Locking: lock() non interruptible + no msg notification if lock still held**
- **JDBC Locking: nodeId written to DB to identify lock creator**
- **JDBC Locking: better detection if DB insert failed due to row with same lock id**
- **JDBC Locking: Fixing lazy initialization**
- **JDBC Locking: Commenting out special environment tests**
- **JDBC Locking: Improving unlock notification via Messaging**
- **JDBC Locking: ensuring only owned locks are being refreshed**
- **JDBC Locking: improved handling of underlying DB exceptions**
- **JDBC Locking: minor (measure internally in nanos, commentes...)**
- **JDBC Locking: improving efficiency**
