### PR TITLE
Complete messaging context propagation and configuration tooling

### DIFF
--- a/gm-mq-rpc/src/com/braintribe/model/processing/mqrpc/server/GmMqRpcServer.java
+++ b/gm-mq-rpc/src/com/braintribe/model/processing/mqrpc/server/GmMqRpcServer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.braintribe.cfg.Configurable;
 import com.braintribe.cfg.LifecycleAware;
@@ -112,6 +113,7 @@ public class GmMqRpcServer implements MessageListener, LifecycleAware, Worker {
 	private ThreadRenamer threadRenamer = ThreadRenamer.NO_OP;
 	private boolean trusted;
 	private long keepAliveInterval;
+	private Supplier<AttributeContext> attributeContextProvider = AttributeContexts::peek;
 
 	// internals
 	private String fromTag;
@@ -222,6 +224,16 @@ public class GmMqRpcServer implements MessageListener, LifecycleAware, Worker {
 	@Configurable
 	public void setKeepAliveInterval(long keepAliveInterval) {
 		this.keepAliveInterval = keepAliveInterval;
+	}
+
+	/**
+	 * Configures the context on top of which transport attributes are added for
+	 * incoming requests. The current thread context remains the default for
+	 * backwards compatibility.
+	 */
+	@Configurable
+	public void setAttributeContextProvider(Supplier<AttributeContext> attributeContextProvider) {
+		this.attributeContextProvider = Objects.requireNonNull(attributeContextProvider, "attributeContextProvider must not be null");
 	}
 
 	// ################################################
@@ -452,7 +464,7 @@ public class GmMqRpcServer implements MessageListener, LifecycleAware, Worker {
 		Map<String, Object> headers = requestMessage.getHeaders();
 		Map<String,Object> properties = requestMessage.getProperties();
 
-		AttributeContext attributeContext = AttributeContexts.peek();
+		AttributeContext attributeContext = attributeContextProvider.get();
 
 		//@formatter:off
 		AttributeContextBuilder builder = attributeContext.derive()

--- a/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/index/ClasspathIndexTest.java
+++ b/modeled-yaml-config-test/src/com/braintribe/gm/config/yaml/index/ClasspathIndexTest.java
@@ -2,6 +2,7 @@ package com.braintribe.gm.config.yaml.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -85,11 +86,30 @@ public class ClasspathIndexTest {
 			writeZipEntry(out, "HICONIC-CONF/example.yaml", "example: true\n");
 		}
 
-		try (URLClassLoader classLoader = new URLClassLoader(new java.net.URL[] { archive.toUri().toURL() }, null)) {
+		try (URLClassLoader classLoader = new URLClassLoader(new URL[] { archive.toUri().toURL() }, null)) {
 			List<ClasspathEntry> entries = new ClasspathIndex(classLoader).all();
 
 			assertThat(entries).hasSize(1);
 			assertThat(entries.get(0).path).isEqualTo("HICONIC-CONF/example.yaml");
+		}
+	}
+
+	@Test
+	public void infersArtifactOriginFromEclipseProjectOutput() throws Exception {
+		Path project = temporaryFolder.newFolder("example-configuration").toPath();
+		Path output = project.resolve("classes");
+		Path config = output.resolve("HICONIC-CONF/example-configuration.yaml");
+		Path index = output.resolve("META-INF/classpath-index.txt");
+		Files.createDirectories(config.getParent());
+		Files.createDirectories(index.getParent());
+		Files.writeString(config, "example: true\n", StandardCharsets.UTF_8);
+		Files.writeString(index, "HICONIC-CONF/example-configuration.yaml\n", StandardCharsets.UTF_8);
+
+		try (URLClassLoader classLoader = new URLClassLoader(new URL[] { output.toUri().toURL() }, null)) {
+			List<ClasspathEntry> entries = new ClasspathIndex(classLoader).all();
+
+			assertThat(entries).hasSize(1);
+			assertThat(entries.get(0).origin).isEqualTo("example-configuration");
 		}
 	}
 

--- a/modeled-yaml-config/src/com/braintribe/gm/config/yaml/index/ClasspathIndex.java
+++ b/modeled-yaml-config/src/com/braintribe/gm/config/yaml/index/ClasspathIndex.java
@@ -6,6 +6,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -365,6 +366,29 @@ public class ClasspathIndex {
 			String artifactWithVersion = value.substring(slash + 1, jarEnd);
 			int versionSeparator = artifactWithVersion.lastIndexOf('-');
 			return versionSeparator > 0 ? artifactWithVersion.substring(0, versionSeparator) : artifactWithVersion;
+		}
+
+		/*
+		 * Eclipse exposes project resources from the configured output directory,
+		 * e.g. <project>/classes/META-INF/classpath-index.txt. Unlike a jar URL this
+		 * URL carries no artifact coordinates, but the project directory is the
+		 * artifact id by DevRock convention. Maven-style target/classes and
+		 * build/classes layouts are handled as well for standalone classpaths.
+		 */
+		if ("file".equals(indexFileUrl.getProtocol())) {
+			try {
+				Path index = Path.of(indexFileUrl.toURI());
+				Path outputDirectory = index.getParent() == null ? null : index.getParent().getParent();
+				Path artifactDirectory = outputDirectory == null ? null : outputDirectory.getParent();
+				if (artifactDirectory != null && ("target".equals(artifactDirectory.getFileName().toString())
+						|| "build".equals(artifactDirectory.getFileName().toString())))
+					artifactDirectory = artifactDirectory.getParent();
+
+				if (artifactDirectory != null && artifactDirectory.getFileName() != null)
+					return artifactDirectory.getFileName().toString();
+			} catch (URISyntaxException e) {
+				throw new IllegalStateException("Invalid filesystem classpath index URL: " + indexFileUrl, e);
+			}
 		}
 		return "";
 	}

--- a/security-service-api-model/src/com/braintribe/model/securityservice/web/WebAuthorizationRequest.java
+++ b/security-service-api-model/src/com/braintribe/model/securityservice/web/WebAuthorizationRequest.java
@@ -32,6 +32,12 @@ import com.braintribe.model.service.api.ServiceRequest;
 public interface WebAuthorizationRequest extends ServiceRequest {
 
 	EntityType<WebAuthorizationRequest> T = EntityTypes.T(WebAuthorizationRequest.class);
+	String webAuthDomainId = "web-auth";
+
+	@Override
+	default String domainId() {
+		return webAuthDomainId;
+	}
 
 	@Override
 	default boolean system() {


### PR DESCRIPTION
## Summary
- adds a backwards-compatible AttributeContext provider hook to GmMqRpcServer for trusted RX system evaluation
- assigns web authorization requests to their canonical web-auth domain
- infers classpath resource provenance from Eclipse and standalone filesystem output directories
- retains the Windows classpath-index compatibility added on main

## Verification
- rebased onto current origin/main
- gm-mq-rpc and security-service-api-model install successfully
- modeled-yaml-config and modeled-yaml-config-test install successfully
- full modeled-yaml-config test suite passes, including Windows separators and Eclipse output provenance
- downstream casting-via-messaging-rx-module compiles against the installed API
- Java/model Eclipse descriptor audit is clean

The GmMqRpcServer default remains AttributeContexts.peek(), preserving existing CX behavior unless the new provider is explicitly configured.