### PR TITLE
Defer initializer database access until execution

### DIFF
--- a/initializer-manager-jdbc-test/src/com/braintribe/gm/initializer/jdbc/processing/GmDbInitializerManagerTest.java
+++ b/initializer-manager-jdbc-test/src/com/braintribe/gm/initializer/jdbc/processing/GmDbInitializerManagerTest.java
@@ -1,5 +1,10 @@
 package com.braintribe.gm.initializer.jdbc.processing;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.sql.DataSource;
 
 import org.junit.After;
@@ -62,6 +67,24 @@ public class GmDbInitializerManagerTest extends AbstractInitializerManagerTest<G
 	@Override @Test public void failingTask_DoesNotUpdateFingerprint() { super.failingTask_DoesNotUpdateFingerprint(); }
 	@Override @Test public void exceptionInTask_DoesNotUpdateFingerprint() { super.exceptionInTask_DoesNotUpdateFingerprint(); }
 	// @formatter:on
+
+	@Test
+	public void configuringDataSourceDoesNotOpenConnection() {
+		AtomicInteger invocations = new AtomicInteger();
+		DataSource dataSource = (DataSource) Proxy.newProxyInstance( //
+				DataSource.class.getClassLoader(), //
+				new Class<?>[] { DataSource.class }, //
+				(proxy, method, args) -> {
+					invocations.incrementAndGet();
+					throw new AssertionError("DataSource must not be accessed while configuring the initializer manager: " + method.getName());
+				});
+
+		GmDbInitializerManager manager = new GmDbInitializerManager();
+		manager.setDataSource(dataSource);
+		manager.runInitializers(); // no registered tasks must not initialize the database either
+
+		assertThat(invocations).hasValue(0);
+	}
 
 	@Override
 	protected GmDbInitializerManager newManager() {

--- a/initializer-manager-jdbc/src/com/braintribe/gm/initializer/jdbc/processing/GmDbInitializerManager.java
+++ b/initializer-manager-jdbc/src/com/braintribe/gm/initializer/jdbc/processing/GmDbInitializerManager.java
@@ -32,19 +32,28 @@ public class GmDbInitializerManager extends AbstractInitializerManager {
 	private static final Logger log = Logger.getLogger(GmDbInitializerManager.TaskEntry.class);
 
 	private String nodeId;
-	private GmDb gmDb;
+	private DataSource dataSource;
 	private String tableName;
 	private Locking locking;
 
+	private final Lazy<GmDb> gmDbLazy = new Lazy<>(this::newGmDb);
 	private final Lazy<TasksTable> tasksTableLazy = new Lazy<GmDbInitializerManager.TasksTable>(TasksTable::new);
 
 	// @formatter:off
 	/** Node id to be inserted to the DB table as updatedBy. */
 	@Required public void setNodeId(String nodeId) { this.nodeId = nodeId; }
-	@Required public void setDataSource(DataSource dataSource) { this.gmDb = GmDb.newDb(dataSource).done(); }
+	/**
+	 * Configures the data source without accessing it. Initializer managers are created while modules register their initializer tasks, which may
+	 * happen before a deployed data source is available. The connection and dialect are therefore resolved lazily when initializers actually run.
+	 */
+	@Required public void setDataSource(DataSource dataSource) { this.dataSource = nonNull(dataSource, "dataSource"); }
 	@Required public void setTasksTableName(String tableName) { this.tableName = nonNull(tableName, "tableName"); }
 	@Required public void setLocking(Locking locking) { this.locking = nonNull(locking, "locking"); }
 	// @formatter:on
+
+	private GmDb newGmDb() {
+		return GmDb.newDb(dataSource).done();
+	}
 
 	// #################################################
 	// ## . . . . . . . Initialization . . . . . . . .##
@@ -151,6 +160,7 @@ public class GmDbInitializerManager extends AbstractInitializerManager {
 	}
 
 	private class TasksTable {
+		private final GmDb gmDb = gmDbLazy.get();
 
 		private final GmColumn<Long> colId = gmDb.autoIncrementPrimaryKeyCol("id");
 		private final GmColumn<Date> colCreated = gmDb.date("created").notNull().done();


### PR DESCRIPTION
## Summary
- keep `GmDbInitializerManager` configuration free of JDBC access
- initialize `GmDb` lazily only when registered initializers actually run
- cover the lifecycle boundary with a regression test

## Motivation
The platform exposes the initializer registry while modules are still being wired. A deployed `DataSource` proxy can be created at that point, but its deployment is not active yet. Constructing `GmDb` in `setDataSource` immediately performs dialect detection and resolves the proxy too early.

## Verification
- `hc install` in `initializer-manager-jdbc`
- `hc compile` and `hc test` in `initializer-manager-jdbc-test`
- all 19 unit tests successful